### PR TITLE
feat: add HyperOS Rust/Flutter dp/font scaling support

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -35,7 +35,7 @@ jobs:
         shell: bash
         run: |
           (yes || true) | sdkmanager --licenses > /dev/null
-          sdkmanager "platform-tools" "platforms;android-36" "build-tools;36.1.0"
+          sdkmanager "platform-tools" "platforms;android-36" "build-tools;36.1.0" "cmake;3.22.1" "ndk;28.2.13676358"
 
       - name: Ensure gradlew is executable
         run: chmod +x gradlew

--- a/.gitignore
+++ b/.gitignore
@@ -2,6 +2,7 @@
 .gradle/
 build/
 **/build/
+**/.cxx/
 local.properties
 captures/
 

--- a/app/build.gradle.kts
+++ b/app/build.gradle.kts
@@ -1,6 +1,10 @@
 import org.gradle.api.DefaultTask
+import org.gradle.api.file.DirectoryProperty
+import org.gradle.api.file.ConfigurableFileTree
 import org.gradle.api.file.RegularFileProperty
 import org.gradle.api.tasks.Internal
+import org.gradle.api.tasks.InputFiles
+import org.gradle.api.tasks.OutputDirectory
 import org.gradle.api.tasks.OutputFile
 import org.gradle.api.tasks.TaskAction
 
@@ -98,6 +102,12 @@ android {
         versionName = appVersionName
         versionCode = semVerToVersionCode(appVersionName)
         testInstrumentationRunner = "androidx.test.runner.AndroidJUnitRunner"
+
+        externalNativeBuild {
+            cmake {
+                arguments += "-DANDROID_STL=c++_static"
+            }
+        }
     }
 
     signingConfigs {
@@ -130,6 +140,9 @@ android {
     }
 
     packaging {
+        jniLibs {
+            useLegacyPackaging = true
+        }
         resources {
             merges += "META-INF/xposed/*"
             excludes += "**"
@@ -144,6 +157,51 @@ android {
 
     buildFeatures {
         buildConfig = true
+    }
+
+    externalNativeBuild {
+        cmake {
+            path = file("src/main/cpp/CMakeLists.txt")
+        }
+    }
+}
+
+abstract class SyncNativeProxyAssetTask : DefaultTask() {
+    @get:InputFiles
+    abstract val sourceFiles: ConfigurableFileTree
+
+    @get:OutputDirectory
+    abstract val outputDirectory: DirectoryProperty
+
+    @TaskAction
+    fun syncNativeProxyAsset() {
+        val output = outputDirectory.get().asFile
+        if (output.exists()) {
+            output.deleteRecursively()
+        }
+        sourceFiles.files.forEach { source ->
+            val abi = source.parentFile.name
+            val target = output.resolve("native/$abi/libdpis_native.so")
+            target.parentFile.mkdirs()
+            source.copyTo(target, overwrite = true)
+        }
+    }
+}
+
+androidComponents {
+    onVariants(selector().all()) { variant ->
+        val capitalizedName = variant.name.replaceFirstChar { char ->
+            if (char.isLowerCase()) char.titlecase() else char.toString()
+        }
+        val syncNativeProxy = tasks.register<SyncNativeProxyAssetTask>(
+            "sync${capitalizedName}NativeProxyAsset"
+        ) {
+            sourceFiles.setDir(layout.buildDirectory.dir("intermediates/cxx/${variant.name}"))
+            sourceFiles.include("**/obj/*/libdpis_native.so")
+            outputDirectory.set(layout.buildDirectory.dir("generated/assets/nativeProxy/${variant.name}"))
+            dependsOn("externalNativeBuild${capitalizedName}")
+        }
+        variant.sources.assets?.addGeneratedSourceDirectory(syncNativeProxy) { it.outputDirectory }
     }
 }
 

--- a/app/proguard-rules.pro
+++ b/app/proguard-rules.pro
@@ -1,3 +1,8 @@
 -adaptresourcefilenames
 -keep class com.dpis.module.ModuleMain
 -keep class com.dpis.module.ModuleMain { *; }
+
+-keep class com.dpis.module.HyperOsFlutterFontHookInstaller { *; }
+-keepclasseswithmembernames class * {
+    native <methods>;
+}

--- a/app/src/main/AndroidManifest.xml
+++ b/app/src/main/AndroidManifest.xml
@@ -6,7 +6,6 @@
     <uses-permission android:name="android.permission.REQUEST_INSTALL_PACKAGES" />
 
     <uses-permission android:name="android.permission.SYSTEM_ALERT_WINDOW" />
-
     <uses-permission
         android:name="android.permission.QUERY_ALL_PACKAGES"
         tools:ignore="QueryAllPackagesPermission" />
@@ -42,6 +41,13 @@
             android:name=".OpenSourceLicenseActivity"
             android:exported="false" />
         <activity
+            android:name=".FontDebugStatsIngestActivity"
+            android:excludeFromRecents="true"
+            android:exported="false"
+            android:finishOnTaskLaunch="true"
+            android:noHistory="true"
+            android:theme="@style/Theme.Dpis.Ingest" />
+        <activity
             android:name=".MainActivity"
             android:exported="true">
             <intent-filter>
@@ -66,7 +72,7 @@
         <receiver
             android:name=".FontDebugStatsReceiver"
             android:enabled="true"
-            android:exported="true">
+            android:exported="false">
             <intent-filter>
                 <action android:name="io.github.kwensiu.dpis.ACTION_FONT_DEBUG_STATS_UPDATE" />
             </intent-filter>
@@ -74,6 +80,17 @@
 
         <service
             android:name=".FontDebugOverlayService"
+            android:enabled="true"
+            android:exported="false" />
+
+        <service
+            android:name=".FontDebugStatsIngestService"
+            android:enabled="true"
+            android:exported="false" />
+
+        <provider
+            android:name=".FontDebugStatsProvider"
+            android:authorities="${applicationId}.fontdebugstats"
             android:enabled="true"
             android:exported="false" />
 

--- a/app/src/main/AndroidManifest.xml
+++ b/app/src/main/AndroidManifest.xml
@@ -78,6 +78,15 @@
             </intent-filter>
         </receiver>
 
+        <receiver
+            android:name=".DpisPackageLifecycleReceiver"
+            android:enabled="true"
+            android:exported="false">
+            <intent-filter>
+                <action android:name="android.intent.action.MY_PACKAGE_REPLACED" />
+            </intent-filter>
+        </receiver>
+
         <service
             android:name=".FontDebugOverlayService"
             android:enabled="true"

--- a/app/src/main/assets/native_init
+++ b/app/src/main/assets/native_init
@@ -1,0 +1,1 @@
+libdpis_native.so

--- a/app/src/main/cpp/CMakeLists.txt
+++ b/app/src/main/cpp/CMakeLists.txt
@@ -1,0 +1,9 @@
+cmake_minimum_required(VERSION 3.22.1)
+
+project(dpis_native)
+
+add_library(dpis_native SHARED dpis_native.cpp)
+
+target_compile_features(dpis_native PRIVATE cxx_std_20)
+target_compile_options(dpis_native PRIVATE -Wall -Wextra -Werror)
+target_link_libraries(dpis_native log dl)

--- a/app/src/main/cpp/dpis_native.cpp
+++ b/app/src/main/cpp/dpis_native.cpp
@@ -1,4 +1,4 @@
-﻿#include <android/log.h>
+#include <android/log.h>
 #include <dlfcn.h>
 #include <jni.h>
 #include <link.h>
@@ -284,6 +284,10 @@ std::string read_system_property(const char *key) {
     return std::string(value, static_cast<size_t>(length));
 }
 
+bool is_enabled_value(const std::string &value) {
+    return value == "1" || value == "true" || value == "enabled";
+}
+
 std::string read_environment(const char *key) {
     if (key == nullptr || key[0] == '\0') {
         return {};
@@ -445,6 +449,8 @@ void try_hook_flutter(void *handle) {
 
 void on_library_loaded(const char *name, void *handle) {
     if (ends_with(name, kTargetLibrary)) {
+        log_info("native_init on_library_loaded target: process=" + current_process_name()
+                + " name=" + (name == nullptr ? std::string("") : std::string(name)));
         try_hook_flutter(handle);
     }
 }
@@ -500,7 +506,12 @@ void try_hook_flutter_without_lsposed() {
 void proxy_constructor() {
     log_info("HyperOS proxy constructor: process=" + current_process_name());
     refresh_property_config();
-    load_original_rust_binary();
+    if (is_enabled_value(read_environment("DPIS_NATIVE_SKIP_ORIGINAL"))
+            || is_enabled_value(read_system_property("debug.dpis.native.skip_original"))) {
+        log_info("HyperOS proxy original load skipped: preload mode");
+    } else {
+        load_original_rust_binary();
+    }
     try_hook_flutter_without_lsposed();
 }
 
@@ -690,6 +701,9 @@ NativeOnModuleLoaded native_init(const NativeAPIEntries *entries) {
     if (entries != nullptr) {
         g_hook_func = entries->hook_func;
     }
-    log_info("native_init ready");
+    log_info("native_init ready: process=" + current_process_name()
+            + " entries=" + std::to_string(reinterpret_cast<uintptr_t>(entries))
+            + " hook=" + std::to_string(reinterpret_cast<uintptr_t>(g_hook_func)));
+    try_hook_flutter_without_lsposed();
     return on_library_loaded;
 }

--- a/app/src/main/cpp/dpis_native.cpp
+++ b/app/src/main/cpp/dpis_native.cpp
@@ -1,0 +1,695 @@
+﻿#include <android/log.h>
+#include <dlfcn.h>
+#include <jni.h>
+#include <link.h>
+#include <sys/mman.h>
+#include <sys/system_properties.h>
+#include <unistd.h>
+
+#include <atomic>
+#include <cmath>
+#include <cstdio>
+#include <cstdlib>
+#include <cstdint>
+#include <cstring>
+#include <cerrno>
+#include <string>
+
+namespace {
+
+constexpr const char *kLogTag = "DPIS_NATIVE";
+constexpr const char *kTargetLibrary = "libhyper_os_flutter.so";
+constexpr const char *kHyperOsAppPublicLibrary = "libhyper_os_app_public.so";
+constexpr uintptr_t kParagraphBuilderCreateOffset = 0x81c368;
+constexpr uintptr_t kParagraphBuilderPushStyleOffset = 0x82370c;
+constexpr double kMinScale = 0.25;
+constexpr double kMaxScale = 8.0;
+#if defined(__aarch64__)
+constexpr size_t kInlineHookPatchBytes = 20;
+#endif
+
+using HookFunType = int (*)(void *func, void *replace, void **backup);
+using UnhookFunType = int (*)(void *func);
+using NativeOnModuleLoaded = void (*)(const char *name, void *handle);
+using HyperOsLaunchMainThread = void (*)();
+using HyperOsAppEntryPoint = void (*)();
+
+struct NativeAPIEntries {
+    uint32_t version;
+    HookFunType hook_func;
+    UnhookFunType unhook_func;
+};
+
+HookFunType g_hook_func = nullptr;
+void *g_backup_create = nullptr;
+void *g_backup_push_style = nullptr;
+std::atomic<int> g_target_font_percent{100};
+std::atomic<bool> g_enabled{false};
+std::atomic<bool> g_configured_from_jni{false};
+std::atomic<bool> g_create_hooked{false};
+std::atomic<bool> g_push_style_hooked{false};
+std::atomic<int> g_property_refresh_budget{256};
+std::atomic<int> g_replace_create_log_budget{16};
+std::atomic<int> g_replace_push_style_log_budget{16};
+
+std::atomic<int> g_last_observed_scale_milli{1000};
+
+void log_info(const std::string &message);
+extern "C" void replace_create_trampoline();
+extern "C" void replace_push_style_trampoline();
+
+#if defined(__aarch64__)
+void emit_mov_abs(uint32_t *code, size_t &index, uintptr_t address) {
+    uint64_t value = static_cast<uint64_t>(address);
+    uint16_t part0 = static_cast<uint16_t>(value & 0xffffu);
+    uint16_t part1 = static_cast<uint16_t>((value >> 16u) & 0xffffu);
+    uint16_t part2 = static_cast<uint16_t>((value >> 32u) & 0xffffu);
+    uint16_t part3 = static_cast<uint16_t>((value >> 48u) & 0xffffu);
+    code[index++] = 0xd2800000u | (static_cast<uint32_t>(part0) << 5u) | 17u;
+    code[index++] = 0xf2a00000u | (static_cast<uint32_t>(part1) << 5u) | (1u << 21u) | 17u;
+    code[index++] = 0xf2c00000u | (static_cast<uint32_t>(part2) << 5u) | (2u << 21u) | 17u;
+    code[index++] = 0xf2e00000u | (static_cast<uint32_t>(part3) << 5u) | (3u << 21u) | 17u;
+}
+
+void emit_abs_branch(uint32_t *code, size_t &index, uintptr_t address, bool link) {
+    emit_mov_abs(code, index, address);
+    code[index++] = link ? 0xd63f0220u : 0xd61f0220u;
+}
+
+bool is_bl(uint32_t instruction) {
+    return (instruction & 0xfc000000u) == 0x94000000u;
+}
+
+bool is_b(uint32_t instruction) {
+    return (instruction & 0xfc000000u) == 0x14000000u;
+}
+
+uintptr_t decode_branch_target(uintptr_t pc, uint32_t instruction) {
+    int32_t imm26 = static_cast<int32_t>(instruction & 0x03ffffffu);
+    if ((imm26 & 0x02000000) != 0) {
+        imm26 |= static_cast<int32_t>(0xfc000000u);
+    }
+    return pc + (static_cast<int64_t>(imm26) << 2);
+}
+
+bool make_writable_executable(void *address, size_t length) {
+    long page_size = sysconf(_SC_PAGESIZE);
+    if (page_size <= 0) {
+        page_size = 4096;
+    }
+    uintptr_t start = reinterpret_cast<uintptr_t>(address) & ~(static_cast<uintptr_t>(page_size) - 1u);
+    uintptr_t end = (reinterpret_cast<uintptr_t>(address) + length + page_size - 1u)
+            & ~(static_cast<uintptr_t>(page_size) - 1u);
+    if (mprotect(reinterpret_cast<void *>(start), end - start,
+            PROT_READ | PROT_WRITE | PROT_EXEC) != 0) {
+        log_info("mprotect failed errno=" + std::to_string(errno));
+        return false;
+    }
+    return true;
+}
+
+#endif
+
+int inline_hook_arm64(void *target, void *replacement, void **backup) {
+#if defined(__aarch64__)
+    if (target == nullptr || replacement == nullptr || backup == nullptr) {
+        return -1;
+    }
+    auto *trampoline = static_cast<uint32_t *>(mmap(nullptr, 4096,
+            PROT_READ | PROT_WRITE | PROT_EXEC,
+            MAP_PRIVATE | MAP_ANONYMOUS, -1, 0));
+    if (trampoline == MAP_FAILED) {
+        log_info("inline hook mmap failed errno=" + std::to_string(errno));
+        return -2;
+    }
+    auto *source = reinterpret_cast<uint32_t *>(target);
+    size_t out = 0;
+    for (size_t offset = 0; offset < kInlineHookPatchBytes; offset += sizeof(uint32_t)) {
+        uint32_t instruction = source[offset / sizeof(uint32_t)];
+        uintptr_t pc = reinterpret_cast<uintptr_t>(target) + offset;
+        if (is_bl(instruction)) {
+            emit_abs_branch(trampoline, out, decode_branch_target(pc, instruction), true);
+        } else if (is_b(instruction)) {
+            emit_abs_branch(trampoline, out, decode_branch_target(pc, instruction), false);
+        } else {
+            trampoline[out++] = instruction;
+        }
+    }
+    emit_abs_branch(trampoline, out,
+            reinterpret_cast<uintptr_t>(target) + kInlineHookPatchBytes, false);
+    __builtin___clear_cache(reinterpret_cast<char *>(trampoline),
+            reinterpret_cast<char *>(trampoline + out));
+
+    if (!make_writable_executable(target, kInlineHookPatchBytes)) {
+        munmap(trampoline, 4096);
+        return -3;
+    }
+    uint32_t patch[5] = {};
+    size_t patch_index = 0;
+    emit_abs_branch(patch, patch_index, reinterpret_cast<uintptr_t>(replacement), false);
+    std::memcpy(target, patch, sizeof(patch));
+    __builtin___clear_cache(reinterpret_cast<char *>(target),
+            reinterpret_cast<char *>(target) + sizeof(patch));
+    *backup = trampoline;
+    return 0;
+#else
+    (void) target;
+    (void) replacement;
+    (void) backup;
+    return -10;
+#endif
+}
+
+void log_info(const char *message) {
+    __android_log_write(ANDROID_LOG_INFO, kLogTag, message);
+}
+
+void log_info(const std::string &message) {
+    log_info(message.c_str());
+}
+
+bool ends_with(const char *text, const char *suffix) {
+    if (text == nullptr || suffix == nullptr) {
+        return false;
+    }
+    size_t text_len = std::strlen(text);
+    size_t suffix_len = std::strlen(suffix);
+    return text_len >= suffix_len
+            && std::strcmp(text + text_len - suffix_len, suffix) == 0;
+}
+
+struct BaseLookup {
+    const char *name;
+    uintptr_t base;
+};
+
+int find_base_callback(struct dl_phdr_info *info, size_t, void *data) {
+    auto *lookup = static_cast<BaseLookup *>(data);
+    if (info == nullptr || lookup == nullptr || !ends_with(info->dlpi_name, lookup->name)) {
+        return 0;
+    }
+    lookup->base = static_cast<uintptr_t>(info->dlpi_addr);
+    return 1;
+}
+
+uintptr_t find_library_base(const char *name) {
+    BaseLookup lookup{name, 0};
+    dl_iterate_phdr(find_base_callback, &lookup);
+    return lookup.base;
+}
+
+double clamp(double value, double min_value, double max_value) {
+    if (value < min_value) {
+        return min_value;
+    }
+    if (value > max_value) {
+        return max_value;
+    }
+    return value;
+}
+
+double target_scale() {
+    int percent = g_target_font_percent.load(std::memory_order_relaxed);
+    if (percent <= 0) {
+        return 1.0;
+    }
+    return static_cast<double>(percent) / 100.0;
+}
+
+std::string current_process_name() {
+    FILE *file = std::fopen("/proc/self/cmdline", "re");
+    if (file == nullptr) {
+        return {};
+    }
+    char buffer[256] = {};
+    size_t read = std::fread(buffer, 1, sizeof(buffer) - 1, file);
+    std::fclose(file);
+    if (read == 0) {
+        return {};
+    }
+    return std::string(buffer);
+}
+
+std::string read_proc_cmdline_value(const char *key) {
+    if (key == nullptr || key[0] == '\0') {
+        return {};
+    }
+    FILE *file = std::fopen("/proc/self/cmdline", "re");
+    if (file == nullptr) {
+        return {};
+    }
+    char buffer[4096] = {};
+    size_t read = std::fread(buffer, 1, sizeof(buffer) - 1, file);
+    std::fclose(file);
+    if (read == 0) {
+        return {};
+    }
+    std::string prefix = std::string(key) + "=";
+    size_t index = 0;
+    while (index < read) {
+        const char *entry = buffer + index;
+        size_t length = std::strlen(entry);
+        if (length == 0) {
+            index++;
+            continue;
+        }
+        std::string item(entry, length);
+        size_t start = 0;
+        while (start < item.size()) {
+            size_t end = item.find(' ', start);
+            std::string token = item.substr(start,
+                    end == std::string::npos ? std::string::npos : end - start);
+            if (token.rfind(prefix, 0) == 0) {
+                return token.substr(prefix.size());
+            }
+            if (end == std::string::npos) {
+                break;
+            }
+            start = end + 1;
+        }
+        index += length + 1;
+    }
+    return {};
+}
+
+std::string read_system_property(const char *key) {
+    if (key == nullptr || key[0] == '\0') {
+        return {};
+    }
+    char value[PROP_VALUE_MAX] = {};
+    int length = __system_property_get(key, value);
+    if (length <= 0) {
+        return {};
+    }
+    return std::string(value, static_cast<size_t>(length));
+}
+
+std::string read_environment(const char *key) {
+    if (key == nullptr || key[0] == '\0') {
+        return {};
+    }
+    const char *value = std::getenv(key);
+    if (value == nullptr || value[0] == '\0') {
+        return {};
+    }
+    return std::string(value);
+}
+
+uint32_t java_string_hash(const std::string &text) {
+    uint32_t hash = 0;
+    for (unsigned char ch : text) {
+        hash = hash * 31u + ch;
+    }
+    return hash;
+}
+
+void refresh_property_config() {
+    if (g_configured_from_jni.load(std::memory_order_relaxed)) {
+        return;
+    }
+    int remaining = g_property_refresh_budget.load(std::memory_order_relaxed);
+    if (remaining <= 0) {
+        return;
+    }
+    g_property_refresh_budget.store(remaining - 1, std::memory_order_relaxed);
+    std::string process = current_process_name();
+    if (process.empty()) {
+        return;
+    }
+    char key[PROP_NAME_MAX] = {};
+    uint32_t process_hash = java_string_hash(process);
+    std::snprintf(key, sizeof(key), "debug.dpis.forcefont.%08x", process_hash);
+    std::string value = read_system_property(key);
+    if (value.empty()) {
+        value = read_system_property("debug.dpis.forcefont");
+    }
+    if (value.empty()) {
+        value = read_environment("DPIS_FONT_SCALE_PERCENT");
+    }
+    if (value.empty()) {
+        value = read_proc_cmdline_value("DPIS_FONT_SCALE_PERCENT");
+    }
+    if (value.empty()) {
+        std::snprintf(key, sizeof(key), "debug.dpis.font.%08x", process_hash);
+        value = read_system_property(key);
+    }
+    if (value.empty()) {
+        return;
+    }
+    int percent = std::atoi(value.c_str());
+    if (percent <= 0) {
+        g_enabled.store(false, std::memory_order_relaxed);
+        return;
+    }
+    g_target_font_percent.store(percent, std::memory_order_relaxed);
+    g_enabled.store(true, std::memory_order_relaxed);
+}
+
+double multiplier_for(double observed_scale) {
+    refresh_property_config();
+    if (!g_enabled.load(std::memory_order_relaxed)
+            || observed_scale <= 0.0
+            || !std::isfinite(observed_scale)) {
+        return 1.0;
+    }
+    int observed_milli = static_cast<int>(observed_scale * 1000.0 + 0.5);
+    if (observed_milli > 0) {
+        g_last_observed_scale_milli.store(observed_milli, std::memory_order_relaxed);
+    }
+    return clamp(target_scale() / observed_scale, kMinScale, kMaxScale);
+}
+
+extern "C" double dpis_create_multiplier(double d0, double d1, double d2) {
+    double multiplier = multiplier_for(d1);
+    int log_budget = g_replace_create_log_budget.load(std::memory_order_relaxed);
+    if (log_budget > 0) {
+        g_replace_create_log_budget.store(log_budget - 1, std::memory_order_relaxed);
+        log_info("HyperOS Flutter ParagraphBuilder::Create override: d0="
+                + std::to_string(d0)
+                + " d1=" + std::to_string(d1)
+                + " d2=" + std::to_string(d2)
+                + " multiplier=" + std::to_string(multiplier));
+    }
+    return multiplier;
+}
+
+extern "C" uintptr_t dpis_create_backup_address() {
+    return reinterpret_cast<uintptr_t>(g_backup_create);
+}
+
+bool is_push_style_experiment_enabled() {
+    std::string value = read_system_property("debug.dpis.pushstyle");
+    if (value == "1" || value == "true" || value == "enabled") {
+        return true;
+    }
+    if (value == "false" || value == "disabled") {
+        return false;
+    }
+    refresh_property_config();
+    return g_enabled.load(std::memory_order_relaxed);
+}
+
+extern "C" double dpis_push_style_multiplier(double observed_scale, double font_size) {
+    double multiplier = multiplier_for(observed_scale);
+    int log_budget = g_replace_push_style_log_budget.load(std::memory_order_relaxed);
+    if (log_budget > 0) {
+        g_replace_push_style_log_budget.store(log_budget - 1, std::memory_order_relaxed);
+        log_info("HyperOS Flutter ParagraphBuilder::pushStyle override: font="
+                + std::to_string(font_size)
+                + " observed=" + std::to_string(observed_scale)
+                + " multiplier=" + std::to_string(multiplier));
+    }
+    return multiplier;
+}
+
+extern "C" uintptr_t dpis_push_style_backup_address() {
+    return reinterpret_cast<uintptr_t>(g_backup_push_style);
+}
+
+void try_hook_flutter(void *handle) {
+    if (handle == nullptr) {
+        return;
+    }
+    uintptr_t base = find_library_base(kTargetLibrary);
+    if (base == 0) {
+        log_info("HyperOS Flutter font hook skipped: base not found");
+        return;
+    }
+    if (!g_create_hooked.exchange(true, std::memory_order_acq_rel)) {
+        void *target = reinterpret_cast<void *>(base + kParagraphBuilderCreateOffset);
+        int result = g_hook_func != nullptr
+                ? g_hook_func(target,
+                        reinterpret_cast<void *>(replace_create_trampoline),
+                        &g_backup_create)
+                : inline_hook_arm64(target,
+                        reinterpret_cast<void *>(replace_create_trampoline),
+                        &g_backup_create);
+        log_info("HyperOS Flutter ParagraphBuilder::Create hook result=" + std::to_string(result));
+    }
+    if (!g_push_style_hooked.exchange(true, std::memory_order_acq_rel)) {
+        if (!is_push_style_experiment_enabled()) {
+            log_info("HyperOS Flutter ParagraphBuilder::pushStyle hook skipped: debug.dpis.pushstyle disabled");
+        } else {
+            void *target = reinterpret_cast<void *>(base + kParagraphBuilderPushStyleOffset);
+            int result = g_hook_func != nullptr
+                    ? g_hook_func(target,
+                            reinterpret_cast<void *>(replace_push_style_trampoline),
+                            &g_backup_push_style)
+                    : inline_hook_arm64(target,
+                            reinterpret_cast<void *>(replace_push_style_trampoline),
+                            &g_backup_push_style);
+            log_info("HyperOS Flutter ParagraphBuilder::pushStyle hook result=" + std::to_string(result));
+        }
+    }
+}
+
+void on_library_loaded(const char *name, void *handle) {
+    if (ends_with(name, kTargetLibrary)) {
+        try_hook_flutter(handle);
+    }
+}
+
+void *load_original_rust_binary() {
+    std::string process = current_process_name();
+    if (process.empty()) {
+        log_info("HyperOS proxy original load skipped: empty process");
+        return nullptr;
+    }
+    char key[PROP_NAME_MAX] = {};
+    std::snprintf(key, sizeof(key), "debug.dpis.rustbin.%08x", java_string_hash(process));
+    std::string path = read_system_property(key);
+    if (path.empty()) {
+        log_info("HyperOS proxy original load skipped: missing property " + std::string(key));
+        return nullptr;
+    }
+    void *handle = dlopen(path.c_str(), RTLD_NOW | RTLD_GLOBAL);
+    const char *error = dlerror();
+    log_info("HyperOS proxy original load: process=" + process
+            + " path=" + path
+            + " handle=" + std::to_string(reinterpret_cast<uintptr_t>(handle))
+            + " error=" + (error == nullptr ? "" : error));
+    return handle;
+}
+
+HyperOsAppEntryPoint find_original_app_entry_point() {
+    void *handle = load_original_rust_binary();
+    if (handle == nullptr) {
+        return nullptr;
+    }
+    auto entry = reinterpret_cast<HyperOsAppEntryPoint>(dlsym(handle, "app_entry_point"));
+    const char *error = dlerror();
+    log_info("HyperOS proxy app_entry_point lookup: entry="
+            + std::to_string(reinterpret_cast<uintptr_t>(entry))
+            + " error=" + (error == nullptr ? "" : error));
+    return entry;
+}
+
+void try_hook_flutter_without_lsposed() {
+    void *local_handle = dlopen(kTargetLibrary, RTLD_NOW | RTLD_NOLOAD);
+    if (local_handle == nullptr) {
+        local_handle = dlopen(kTargetLibrary, RTLD_NOW | RTLD_GLOBAL);
+    }
+    const char *error = dlerror();
+    log_info("HyperOS proxy flutter lookup: handle="
+            + std::to_string(reinterpret_cast<uintptr_t>(local_handle))
+            + " error=" + (error == nullptr ? "" : error));
+    try_hook_flutter(local_handle);
+}
+
+[[gnu::constructor]]
+void proxy_constructor() {
+    log_info("HyperOS proxy constructor: process=" + current_process_name());
+    refresh_property_config();
+    load_original_rust_binary();
+    try_hook_flutter_without_lsposed();
+}
+
+} // namespace
+
+#if defined(__aarch64__)
+extern "C" [[gnu::visibility("default")]] [[gnu::used]] [[gnu::naked]]
+void replace_create_trampoline() {
+    __asm__ volatile(
+            "sub sp, sp, #256\n"
+            "stp x0, x1, [sp, #0]\n"
+            "stp x2, x3, [sp, #16]\n"
+            "stp x4, x5, [sp, #32]\n"
+            "stp x6, x7, [sp, #48]\n"
+            "str x8, [sp, #64]\n"
+            "str x30, [sp, #72]\n"
+            "stp q0, q1, [sp, #80]\n"
+            "stp q2, q3, [sp, #112]\n"
+            "stp q4, q5, [sp, #144]\n"
+            "stp q6, q7, [sp, #176]\n"
+            "bl dpis_create_multiplier\n"
+            "str d0, [sp, #208]\n"
+            "bl dpis_create_backup_address\n"
+            "str x0, [sp, #216]\n"
+            "ldp q0, q1, [sp, #80]\n"
+            "ldp q2, q3, [sp, #112]\n"
+            "ldp q4, q5, [sp, #144]\n"
+            "ldp q6, q7, [sp, #176]\n"
+            "ldr d16, [sp, #208]\n"
+            "fmul d0, d0, d16\n"
+            "fmul d2, d2, d16\n"
+            "ldp x0, x1, [sp, #0]\n"
+            "ldp x2, x3, [sp, #16]\n"
+            "ldp x4, x5, [sp, #32]\n"
+            "ldp x6, x7, [sp, #48]\n"
+            "ldr x8, [sp, #64]\n"
+            "ldr x30, [sp, #72]\n"
+            "ldr x9, [sp, #216]\n"
+            "add sp, sp, #256\n"
+            "cbz x9, 1f\n"
+            "br x9\n"
+            "1:\n"
+            "ret\n");
+}
+
+extern "C" [[gnu::visibility("default")]] [[gnu::used]] [[gnu::naked]]
+void replace_push_style_trampoline() {
+    __asm__ volatile(
+            "sub sp, sp, #256\n"
+            "stp x0, x1, [sp, #0]\n"
+            "stp x2, x3, [sp, #16]\n"
+            "stp x4, x5, [sp, #32]\n"
+            "stp x6, x7, [sp, #48]\n"
+            "str x8, [sp, #64]\n"
+            "str x30, [sp, #72]\n"
+            "stp q0, q1, [sp, #80]\n"
+            "stp q2, q3, [sp, #112]\n"
+            "stp q4, q5, [sp, #144]\n"
+            "stp q6, q7, [sp, #176]\n"
+            "fmov d0, d3\n"
+            "ldr d1, [sp, #80]\n"
+            "bl dpis_push_style_multiplier\n"
+            "str d0, [sp, #208]\n"
+            "bl dpis_push_style_backup_address\n"
+            "str x0, [sp, #216]\n"
+            "ldp q0, q1, [sp, #80]\n"
+            "ldp q2, q3, [sp, #112]\n"
+            "ldp q4, q5, [sp, #144]\n"
+            "ldp q6, q7, [sp, #176]\n"
+            "ldr d16, [sp, #208]\n"
+            "fmul d0, d0, d16\n"
+            "ldp x0, x1, [sp, #0]\n"
+            "ldp x2, x3, [sp, #16]\n"
+            "ldp x4, x5, [sp, #32]\n"
+            "ldp x6, x7, [sp, #48]\n"
+            "ldr x8, [sp, #64]\n"
+            "ldr x30, [sp, #72]\n"
+            "ldr x9, [sp, #216]\n"
+            "add sp, sp, #256\n"
+            "cbz x9, 1f\n"
+            "br x9\n"
+            "1:\n"
+            "ret\n");
+}
+#else
+extern "C" [[gnu::visibility("default")]] [[gnu::used]]
+void replace_create_trampoline() {
+}
+
+extern "C" [[gnu::visibility("default")]] [[gnu::used]]
+void replace_push_style_trampoline() {
+}
+#endif
+
+extern "C" [[gnu::visibility("default")]] [[gnu::used]]
+uintptr_t dpis_resolve_app_entry_point(void *arg0, void *arg1, void *arg8) {
+    log_info("HyperOS proxy app_entry_point entered: process=" + current_process_name()
+            + " x0=" + std::to_string(reinterpret_cast<uintptr_t>(arg0))
+            + " x1=" + std::to_string(reinterpret_cast<uintptr_t>(arg1))
+            + " x8=" + std::to_string(reinterpret_cast<uintptr_t>(arg8)));
+    try_hook_flutter_without_lsposed();
+    HyperOsAppEntryPoint entry = find_original_app_entry_point();
+    return reinterpret_cast<uintptr_t>(entry);
+}
+
+#if defined(__aarch64__)
+extern "C" [[gnu::visibility("default")]] [[gnu::used]] [[gnu::naked]]
+void app_entry_point() {
+    __asm__ volatile(
+            "sub sp, sp, #96\n"
+            "stp x0, x1, [sp, #0]\n"
+            "stp x2, x3, [sp, #16]\n"
+            "stp x4, x5, [sp, #32]\n"
+            "stp x6, x7, [sp, #48]\n"
+            "str x8, [sp, #64]\n"
+            "str x30, [sp, #72]\n"
+            "mov x2, x8\n"
+            "bl dpis_resolve_app_entry_point\n"
+            "mov x9, x0\n"
+            "ldp x0, x1, [sp, #0]\n"
+            "ldp x2, x3, [sp, #16]\n"
+            "ldp x4, x5, [sp, #32]\n"
+            "ldp x6, x7, [sp, #48]\n"
+            "ldr x8, [sp, #64]\n"
+            "ldr x30, [sp, #72]\n"
+            "add sp, sp, #96\n"
+            "cbz x9, 1f\n"
+            "br x9\n"
+            "1:\n"
+            "ret\n");
+}
+#else
+extern "C" [[gnu::visibility("default")]] [[gnu::used]]
+void app_entry_point() {
+    HyperOsAppEntryPoint entry = find_original_app_entry_point();
+    if (entry != nullptr) {
+        entry();
+    }
+}
+#endif
+
+extern "C" [[gnu::visibility("default")]] [[gnu::used]]
+void launch_main_thread() {
+    log_info("HyperOS proxy launch_main_thread entered: process=" + current_process_name());
+    try_hook_flutter_without_lsposed();
+    void *public_handle = dlopen(kHyperOsAppPublicLibrary, RTLD_NOW | RTLD_GLOBAL);
+    if (public_handle == nullptr) {
+        public_handle = dlopen("/system_ext/lib64/libhyper_os_app_public.so", RTLD_NOW | RTLD_GLOBAL);
+    }
+    const char *open_error = dlerror();
+    auto original = reinterpret_cast<HyperOsLaunchMainThread>(
+            dlsym(public_handle, "launch_main_thread"));
+    const char *symbol_error = dlerror();
+    log_info("HyperOS proxy forwarding: publicHandle="
+            + std::to_string(reinterpret_cast<uintptr_t>(public_handle))
+            + " original=" + std::to_string(reinterpret_cast<uintptr_t>(original))
+            + " openError=" + (open_error == nullptr ? "" : open_error)
+            + " symbolError=" + (symbol_error == nullptr ? "" : symbol_error));
+    if (original != nullptr) {
+        original();
+    }
+}
+
+extern "C" JNIEXPORT void JNICALL
+Java_com_dpis_module_HyperOsFlutterFontHookInstaller_configure(JNIEnv *env,
+                                                               jclass,
+                                                               jstring package_name,
+                                                               jint target_font_scale_percent,
+                                                               jboolean enabled) {
+    const char *package_chars = package_name != nullptr
+            ? env->GetStringUTFChars(package_name, nullptr)
+            : nullptr;
+    g_target_font_percent.store(target_font_scale_percent, std::memory_order_relaxed);
+    g_enabled.store(enabled == JNI_TRUE, std::memory_order_relaxed);
+    g_configured_from_jni.store(true, std::memory_order_relaxed);
+    std::string package_text = package_chars != nullptr ? package_chars : "unknown";
+    if (package_chars != nullptr) {
+        env->ReleaseStringUTFChars(package_name, package_chars);
+    }
+    log_info("configured package=" + package_text
+            + " targetFontScalePercent=" + std::to_string(target_font_scale_percent)
+            + " enabled=" + std::to_string(enabled == JNI_TRUE));
+}
+
+extern "C" [[gnu::visibility("default")]] [[gnu::used]]
+NativeOnModuleLoaded native_init(const NativeAPIEntries *entries) {
+    if (entries != nullptr) {
+        g_hook_func = entries->hook_func;
+    }
+    log_info("native_init ready");
+    return on_library_loaded;
+}

--- a/app/src/main/cpp/dpis_native.cpp
+++ b/app/src/main/cpp/dpis_native.cpp
@@ -20,8 +20,14 @@ namespace {
 constexpr const char *kLogTag = "DPIS_NATIVE";
 constexpr const char *kTargetLibrary = "libhyper_os_flutter.so";
 constexpr const char *kHyperOsAppPublicLibrary = "libhyper_os_app_public.so";
+#if defined(__aarch64__)
+constexpr const char *kWeatherRustLibrary = "libweather_app.so";
+#endif
 constexpr uintptr_t kParagraphBuilderCreateOffset = 0x81c368;
 constexpr uintptr_t kParagraphBuilderPushStyleOffset = 0x82370c;
+#if defined(__aarch64__)
+constexpr uintptr_t kWeatherConfigurationFontScaleGotOffset = 0x44c0d8;
+#endif
 constexpr double kMinScale = 0.25;
 constexpr double kMaxScale = 8.0;
 #if defined(__aarch64__)
@@ -43,20 +49,30 @@ struct NativeAPIEntries {
 HookFunType g_hook_func = nullptr;
 void *g_backup_create = nullptr;
 void *g_backup_push_style = nullptr;
+#if defined(__aarch64__)
+void *g_original_weather_configuration_font_scale = nullptr;
+#endif
 std::atomic<int> g_target_font_percent{100};
 std::atomic<bool> g_enabled{false};
 std::atomic<bool> g_configured_from_jni{false};
 std::atomic<bool> g_create_hooked{false};
 std::atomic<bool> g_push_style_hooked{false};
+#if defined(__aarch64__)
+std::atomic<bool> g_weather_configuration_font_scale_hooked{false};
+#endif
 std::atomic<int> g_property_refresh_budget{256};
 std::atomic<int> g_replace_create_log_budget{16};
 std::atomic<int> g_replace_push_style_log_budget{16};
+std::atomic<int> g_weather_configuration_font_scale_log_budget{16};
+std::atomic<int> g_weather_create_d0_remap_log_budget{16};
 
 std::atomic<int> g_last_observed_scale_milli{1000};
 
 void log_info(const std::string &message);
 extern "C" void replace_create_trampoline();
 extern "C" void replace_push_style_trampoline();
+extern "C" float Configuration_get_font_scale(void *configuration);
+extern "C" void app_entry_point();
 
 #if defined(__aarch64__)
 void emit_mov_abs(uint32_t *code, size_t &index, uintptr_t address) {
@@ -108,6 +124,22 @@ bool make_writable_executable(void *address, size_t length) {
     return true;
 }
 
+
+bool make_writable_data(void *address, size_t length) {
+    long page_size = sysconf(_SC_PAGESIZE);
+    if (page_size <= 0) {
+        page_size = 4096;
+    }
+    uintptr_t start = reinterpret_cast<uintptr_t>(address) & ~(static_cast<uintptr_t>(page_size) - 1u);
+    uintptr_t end = (reinterpret_cast<uintptr_t>(address) + length + page_size - 1u)
+            & ~(static_cast<uintptr_t>(page_size) - 1u);
+    if (mprotect(reinterpret_cast<void *>(start), end - start,
+            PROT_READ | PROT_WRITE) != 0) {
+        log_info("mprotect data failed errno=" + std::to_string(errno));
+        return false;
+    }
+    return true;
+}
 #endif
 
 int inline_hook_arm64(void *target, void *replacement, void **backup) {
@@ -197,6 +229,28 @@ uintptr_t find_library_base(const char *name) {
     dl_iterate_phdr(find_base_callback, &lookup);
     return lookup.base;
 }
+
+#if defined(__aarch64__)
+bool is_weather_configuration_font_scale_slot(void *value) {
+    if (value == nullptr) {
+        return false;
+    }
+    Dl_info info = {};
+    if (dladdr(value, &info) == 0 || info.dli_fname == nullptr) {
+        return false;
+    }
+    if (!ends_with(info.dli_fname, kWeatherRustLibrary)) {
+        return false;
+    }
+    if (info.dli_sname != nullptr
+            && std::strcmp(info.dli_sname, "Configuration_get_font_scale") == 0) {
+        return true;
+    }
+    uintptr_t weather_base = find_library_base(kWeatherRustLibrary);
+    uintptr_t address = reinterpret_cast<uintptr_t>(value);
+    return weather_base != 0 && address >= weather_base;
+}
+#endif
 
 double clamp(double value, double min_value, double max_value) {
     if (value < min_value) {
@@ -299,6 +353,28 @@ std::string read_environment(const char *key) {
     return std::string(value);
 }
 
+std::string sibling_original_rust_binary_path() {
+#if defined(__aarch64__)
+    if (current_process_name() != "com.miui.weather2") {
+        return {};
+    }
+    Dl_info info = {};
+    if (dladdr(reinterpret_cast<void *>(app_entry_point), &info) == 0
+            || info.dli_fname == nullptr
+            || info.dli_fname[0] == '\0') {
+        return {};
+    }
+    std::string self_path(info.dli_fname);
+    size_t slash = self_path.rfind('/');
+    if (slash == std::string::npos) {
+        return {};
+    }
+    return self_path.substr(0, slash + 1) + kWeatherRustLibrary;
+#else
+    return {};
+#endif
+}
+
 uint32_t java_string_hash(const std::string &text) {
     uint32_t hash = 0;
     for (unsigned char ch : text) {
@@ -308,9 +384,6 @@ uint32_t java_string_hash(const std::string &text) {
 }
 
 void refresh_property_config() {
-    if (g_configured_from_jni.load(std::memory_order_relaxed)) {
-        return;
-    }
     int remaining = g_property_refresh_budget.load(std::memory_order_relaxed);
     if (remaining <= 0) {
         return;
@@ -327,13 +400,14 @@ void refresh_property_config() {
     if (value.empty()) {
         value = read_system_property("debug.dpis.forcefont");
     }
-    if (value.empty()) {
+    bool configured_from_jni = g_configured_from_jni.load(std::memory_order_relaxed);
+    if (value.empty() && !configured_from_jni) {
         value = read_environment("DPIS_FONT_SCALE_PERCENT");
     }
-    if (value.empty()) {
+    if (value.empty() && !configured_from_jni) {
         value = read_proc_cmdline_value("DPIS_FONT_SCALE_PERCENT");
     }
-    if (value.empty()) {
+    if (value.empty() && !configured_from_jni) {
         std::snprintf(key, sizeof(key), "debug.dpis.font.%08x", process_hash);
         value = read_system_property(key);
     }
@@ -363,8 +437,15 @@ double multiplier_for(double observed_scale) {
     return clamp(target_scale() / observed_scale, kMinScale, kMaxScale);
 }
 
+double create_observed_scale(double observed_scale) {
+    if (observed_scale > 0.0 && std::isfinite(observed_scale)) {
+        return observed_scale;
+    }
+    return 1.0;
+}
+
 extern "C" double dpis_create_multiplier(double d0, double d1, double d2) {
-    double multiplier = multiplier_for(d1);
+    double multiplier = multiplier_for(create_observed_scale(d1));
     int log_budget = g_replace_create_log_budget.load(std::memory_order_relaxed);
     if (log_budget > 0) {
         g_replace_create_log_budget.store(log_budget - 1, std::memory_order_relaxed);
@@ -377,6 +458,26 @@ extern "C" double dpis_create_multiplier(double d0, double d1, double d2) {
     return multiplier;
 }
 
+extern "C" double dpis_create_scaled_d0(double original_d0,
+                                        double original_d2,
+                                        double multiplier) {
+    if (current_process_name() == "com.miui.weather2"
+            && original_d0 <= 0.0
+            && original_d2 > 0.0
+            && std::isfinite(original_d2)) {
+        double scaled = original_d2 * multiplier;
+        int log_budget = g_weather_create_d0_remap_log_budget.load(std::memory_order_relaxed);
+        if (log_budget > 0) {
+            g_weather_create_d0_remap_log_budget.store(log_budget - 1, std::memory_order_relaxed);
+            log_info("HyperOS Weather Create d0 remap: d0="
+                    + std::to_string(original_d0)
+                    + " d2=" + std::to_string(original_d2)
+                    + " scaled=" + std::to_string(scaled));
+        }
+        return scaled;
+    }
+    return original_d0 * multiplier;
+}
 extern "C" uintptr_t dpis_create_backup_address() {
     return reinterpret_cast<uintptr_t>(g_backup_create);
 }
@@ -408,6 +509,57 @@ extern "C" double dpis_push_style_multiplier(double observed_scale, double font_
 
 extern "C" uintptr_t dpis_push_style_backup_address() {
     return reinterpret_cast<uintptr_t>(g_backup_push_style);
+}
+
+extern "C" [[gnu::visibility("default")]] float Configuration_get_font_scale(void *configuration) {
+    refresh_property_config();
+    float value = static_cast<float>(target_scale());
+    int log_budget = g_weather_configuration_font_scale_log_budget.load(std::memory_order_relaxed);
+    if (log_budget > 0) {
+        g_weather_configuration_font_scale_log_budget.store(log_budget - 1, std::memory_order_relaxed);
+        log_info("HyperOS Configuration_get_font_scale override: process=" + current_process_name()
+                + " value=" + std::to_string(value)
+                + " config=" + std::to_string(reinterpret_cast<uintptr_t>(configuration)));
+    }
+    return value;
+}
+
+void try_hook_weather_configuration_font_scale() {
+#if defined(__aarch64__)
+    if (current_process_name() != "com.miui.weather2") {
+        return;
+    }
+    if (g_weather_configuration_font_scale_hooked.load(std::memory_order_acquire)) {
+        return;
+    }
+    uintptr_t base = find_library_base(kWeatherRustLibrary);
+    if (base == 0) {
+        log_info("HyperOS Weather Configuration_get_font_scale GOT hook skipped: base not found");
+        return;
+    }
+    auto *slot = reinterpret_cast<void **>(base + kWeatherConfigurationFontScaleGotOffset);
+    if (!is_weather_configuration_font_scale_slot(*slot)) {
+        log_info("HyperOS Weather Configuration_get_font_scale GOT hook skipped: unexpected slot="
+                + std::to_string(reinterpret_cast<uintptr_t>(*slot)));
+        return;
+    }
+    if (!make_writable_data(slot, sizeof(void *))) {
+        log_info("HyperOS Weather Configuration_get_font_scale GOT hook failed: mprotect");
+        return;
+    }
+    g_original_weather_configuration_font_scale = *slot;
+    *slot = reinterpret_cast<void *>(Configuration_get_font_scale);
+    __builtin___clear_cache(reinterpret_cast<char *>(slot),
+            reinterpret_cast<char *>(slot) + sizeof(void *));
+    g_weather_configuration_font_scale_hooked.store(true, std::memory_order_release);
+    log_info("HyperOS Weather Configuration_get_font_scale GOT hook installed: base="
+            + std::to_string(base)
+            + " slot=" + std::to_string(reinterpret_cast<uintptr_t>(slot))
+            + " original=" + std::to_string(
+                    reinterpret_cast<uintptr_t>(g_original_weather_configuration_font_scale)));
+#else
+    log_info("HyperOS Weather Configuration_get_font_scale GOT hook skipped: unsupported arch");
+#endif
 }
 
 void try_hook_flutter(void *handle) {
@@ -461,12 +613,18 @@ void *load_original_rust_binary() {
         log_info("HyperOS proxy original load skipped: empty process");
         return nullptr;
     }
-    char key[PROP_NAME_MAX] = {};
-    std::snprintf(key, sizeof(key), "debug.dpis.rustbin.%08x", java_string_hash(process));
-    std::string path = read_system_property(key);
+    std::string path = read_environment("DPIS_RUST_BINARY");
     if (path.empty()) {
-        log_info("HyperOS proxy original load skipped: missing property " + std::string(key));
-        return nullptr;
+        path = sibling_original_rust_binary_path();
+    }
+    if (path.empty()) {
+        char key[PROP_NAME_MAX] = {};
+        std::snprintf(key, sizeof(key), "debug.dpis.rustbin.%08x", java_string_hash(process));
+        path = read_system_property(key);
+        if (path.empty() || path == "0") {
+            log_info("HyperOS proxy original load skipped: missing property " + std::string(key));
+            return nullptr;
+        }
     }
     void *handle = dlopen(path.c_str(), RTLD_NOW | RTLD_GLOBAL);
     const char *error = dlerror();
@@ -500,6 +658,7 @@ void try_hook_flutter_without_lsposed() {
             + std::to_string(reinterpret_cast<uintptr_t>(local_handle))
             + " error=" + (error == nullptr ? "" : error));
     try_hook_flutter(local_handle);
+    try_hook_weather_configuration_font_scale();
 }
 
 [[gnu::constructor]]
@@ -534,15 +693,23 @@ void replace_create_trampoline() {
             "stp q6, q7, [sp, #176]\n"
             "bl dpis_create_multiplier\n"
             "str d0, [sp, #208]\n"
+            "ldr d0, [sp, #80]\n"
+            "ldr d1, [sp, #112]\n"
+            "ldr d2, [sp, #208]\n"
+            "bl dpis_create_scaled_d0\n"
+            "str d0, [sp, #224]\n"
+            "ldr d0, [sp, #112]\n"
+            "ldr d1, [sp, #208]\n"
+            "fmul d0, d0, d1\n"
+            "str d0, [sp, #232]\n"
             "bl dpis_create_backup_address\n"
             "str x0, [sp, #216]\n"
             "ldp q0, q1, [sp, #80]\n"
             "ldp q2, q3, [sp, #112]\n"
             "ldp q4, q5, [sp, #144]\n"
             "ldp q6, q7, [sp, #176]\n"
-            "ldr d16, [sp, #208]\n"
-            "fmul d0, d0, d16\n"
-            "fmul d2, d2, d16\n"
+            "ldr d0, [sp, #224]\n"
+            "ldr d2, [sp, #232]\n"
             "ldp x0, x1, [sp, #0]\n"
             "ldp x2, x3, [sp, #16]\n"
             "ldp x4, x5, [sp, #32]\n"
@@ -596,6 +763,7 @@ void replace_push_style_trampoline() {
             "1:\n"
             "ret\n");
 }
+
 #else
 extern "C" [[gnu::visibility("default")]] [[gnu::used]]
 void replace_create_trampoline() {
@@ -604,6 +772,7 @@ void replace_create_trampoline() {
 extern "C" [[gnu::visibility("default")]] [[gnu::used]]
 void replace_push_style_trampoline() {
 }
+
 #endif
 
 extern "C" [[gnu::visibility("default")]] [[gnu::used]]

--- a/app/src/main/java/com/dpis/module/AppConfigDialogBinder.java
+++ b/app/src/main/java/com/dpis/module/AppConfigDialogBinder.java
@@ -72,6 +72,7 @@ final class AppConfigDialogBinder {
                 dialogView.findViewById(R.id.dialog_title),
                 dialogView.findViewById(R.id.dialog_package),
                 dialogView.findViewById(R.id.dialog_status),
+                dialogView.findViewById(R.id.dialog_hyperos_native_warning),
                 dialogView.findViewById(R.id.dialog_viewport_input_layout),
                 dialogView.findViewById(R.id.dialog_viewport_input),
                 dialogView.findViewById(R.id.dialog_font_scale_input_layout),
@@ -99,6 +100,7 @@ final class AppConfigDialogBinder {
         views.iconView.setImageDrawable(item.icon);
         views.titleView.setText(item.label);
         views.packageView.setText(item.packageName);
+        bindHyperOsNativeWarning(views.hyperOsNativeWarningView, item);
         views.viewportInputView.setText(item.viewportWidthDp != null
                 ? String.valueOf(item.viewportWidthDp)
                 : "");
@@ -379,6 +381,29 @@ final class AppConfigDialogBinder {
         statusView.setText(dialogStatusText);
     }
 
+    private void bindHyperOsNativeWarning(MaterialTextView warningView, AppListItem item) {
+        if (!item.hyperOsNativeProxyCandidate) {
+            warningView.setVisibility(View.GONE);
+            return;
+        }
+        HyperOsNativeProxyStatus proxyStatus = HyperOsNativeProxyStatus.inspect(activity, item.packageName);
+        int colorAttr = proxyStatus.isPresent()
+                ? androidx.appcompat.R.attr.colorPrimary
+                : androidx.appcompat.R.attr.colorError;
+        int statusColor = MaterialColors.getColor(warningView, colorAttr);
+        warningView.setTextColor(statusColor);
+        warningView.setText(resolveHyperOsNativeWarningText(proxyStatus));
+        warningView.setVisibility(View.VISIBLE);
+    }
+
+    private String resolveHyperOsNativeWarningText(HyperOsNativeProxyStatus proxyStatus) {
+        return switch (proxyStatus.state) {
+            case PRESENT -> activity.getString(R.string.dialog_hyperos_native_proxy_present);
+            case MISSING -> activity.getString(R.string.dialog_hyperos_native_proxy_missing);
+            case UNKNOWN -> activity.getString(R.string.dialog_hyperos_native_proxy_unknown);
+        };
+    }
+
     private static Integer parsePositiveIntOrNullSafe(TextInputEditText inputView) {
         try {
             return parsePositiveIntOrNull(inputView);
@@ -580,6 +605,7 @@ final class AppConfigDialogBinder {
         final MaterialTextView titleView;
         final MaterialTextView packageView;
         final MaterialTextView statusView;
+        final MaterialTextView hyperOsNativeWarningView;
         final TextInputLayout viewportInputLayout;
         final TextInputEditText viewportInputView;
         final TextInputLayout fontInputLayout;
@@ -598,6 +624,7 @@ final class AppConfigDialogBinder {
                 MaterialTextView titleView,
                 MaterialTextView packageView,
                 MaterialTextView statusView,
+                MaterialTextView hyperOsNativeWarningView,
                 TextInputLayout viewportInputLayout,
                 TextInputEditText viewportInputView,
                 TextInputLayout fontInputLayout,
@@ -615,6 +642,7 @@ final class AppConfigDialogBinder {
             this.titleView = titleView;
             this.packageView = packageView;
             this.statusView = statusView;
+            this.hyperOsNativeWarningView = hyperOsNativeWarningView;
             this.viewportInputLayout = viewportInputLayout;
             this.viewportInputView = viewportInputView;
             this.fontInputLayout = fontInputLayout;

--- a/app/src/main/java/com/dpis/module/AppConfigDialogBinder.java
+++ b/app/src/main/java/com/dpis/module/AppConfigDialogBinder.java
@@ -38,6 +38,10 @@ final class AppConfigDialogBinder {
 
         void executeProcessAction(AppListItem item, ProcessAction action);
 
+        void applyHyperOsNativeProxy(AppListItem item, Runnable onFinished);
+
+        void unmountHyperOsNativeProxy(AppListItem item, Runnable onFinished);
+
         boolean setDpisEnabled(String packageName, boolean enabled);
 
         int[] saveAppConfig(AppListItem item,
@@ -243,6 +247,7 @@ final class AppConfigDialogBinder {
                     resolveFontMode(views.fontModeToggle));
             if (result[0] == 1) {
                 showSaveButtonFeedback(views.saveButton);
+                syncHyperOsNativeProxyAfterSave(item, views, state);
             }
             if (result[1] != 0) {
                 host.showToast(result[1]);
@@ -394,6 +399,33 @@ final class AppConfigDialogBinder {
         warningView.setTextColor(statusColor);
         warningView.setText(resolveHyperOsNativeWarningText(proxyStatus));
         warningView.setVisibility(View.VISIBLE);
+    }
+
+    private void syncHyperOsNativeProxyAfterSave(
+            AppListItem item, AppConfigDialogViews views, AppConfigDialogState state) {
+        if (!item.hyperOsNativeProxyCandidate) {
+            return;
+        }
+        setSaveAndResetButtonsEnabled(views, false);
+        Runnable onFinished = () -> {
+            bindHyperOsNativeWarning(views.hyperOsNativeWarningView, item);
+            setSaveAndResetButtonsEnabled(views, true);
+        };
+        if (state.dpisEnabled && hasActiveDialogConfig(views)) {
+            host.applyHyperOsNativeProxy(item, onFinished);
+            return;
+        }
+        host.unmountHyperOsNativeProxy(item, onFinished);
+    }
+
+    private static boolean hasActiveDialogConfig(AppConfigDialogViews views) {
+        return parsePositiveIntOrNullSafe(views.viewportInputView) != null
+                || parsePositiveIntOrNullSafe(views.fontInputView) != null;
+    }
+
+    private static void setSaveAndResetButtonsEnabled(AppConfigDialogViews views, boolean enabled) {
+        views.saveButton.setEnabled(enabled);
+        views.disableButton.setEnabled(enabled);
     }
 
     private String resolveHyperOsNativeWarningText(HyperOsNativeProxyStatus proxyStatus) {

--- a/app/src/main/java/com/dpis/module/AppConfigSaveHandler.java
+++ b/app/src/main/java/com/dpis/module/AppConfigSaveHandler.java
@@ -45,9 +45,16 @@ final class AppConfigSaveHandler {
             if (fontScalePercent == null) {
                 changed = store.clearTargetFontScalePercent(item.packageName) && changed;
                 changed = store.setTargetFontApplyMode(item.packageName, FontApplyMode.OFF) && changed;
+                HyperOsNativeFontPropertySyncer.clearFontTargetAsync(item.packageName);
             } else {
                 changed = store.setTargetFontScalePercent(item.packageName, fontScalePercent) && changed;
                 changed = store.setTargetFontApplyMode(item.packageName, fontMode) && changed;
+                if (FontApplyMode.isEnabled(fontMode)) {
+                    HyperOsNativeFontPropertySyncer.publishForceFontTargetAsync(
+                            item.packageName, fontScalePercent);
+                } else {
+                    HyperOsNativeFontPropertySyncer.clearFontTargetAsync(item.packageName);
+                }
             }
             if (changed && onChanged != null) {
                 onChanged.run();

--- a/app/src/main/java/com/dpis/module/AppConfigSaveHandler.java
+++ b/app/src/main/java/com/dpis/module/AppConfigSaveHandler.java
@@ -37,10 +37,16 @@ final class AppConfigSaveHandler {
                 changed = store.clearTargetViewportWidthDp(item.packageName) && changed;
                 changed = store.setTargetViewportApplyMode(item.packageName, ViewportApplyMode.OFF)
                         && changed;
+                ViewportPropertySyncer.clearTargetAsync(item.packageName);
             } else {
                 changed = store.setTargetViewportWidthDp(item.packageName, widthDp) && changed;
                 changed = store.setTargetViewportApplyMode(item.packageName, viewportMode)
                         && changed;
+                if (ViewportApplyMode.isEnabled(viewportMode)) {
+                    ViewportPropertySyncer.publishTargetAsync(item.packageName, widthDp);
+                } else {
+                    ViewportPropertySyncer.clearTargetAsync(item.packageName);
+                }
             }
             if (fontScalePercent == null) {
                 changed = store.clearTargetFontScalePercent(item.packageName) && changed;

--- a/app/src/main/java/com/dpis/module/AppListItem.java
+++ b/app/src/main/java/com/dpis/module/AppListItem.java
@@ -12,6 +12,7 @@ final class AppListItem {
     final String fontMode;
     final boolean dpisEnabled;
     final boolean systemApp;
+    final boolean hyperOsNativeProxyCandidate;
     final Drawable icon;
 
     AppListItem(String label,
@@ -23,6 +24,7 @@ final class AppListItem {
                 String fontMode,
                 boolean dpisEnabled,
                 boolean systemApp,
+                boolean hyperOsNativeProxyCandidate,
                 Drawable icon) {
         this.label = label;
         this.packageName = packageName;
@@ -33,6 +35,7 @@ final class AppListItem {
         this.fontMode = FontApplyMode.normalize(fontMode);
         this.dpisEnabled = dpisEnabled;
         this.systemApp = systemApp;
+        this.hyperOsNativeProxyCandidate = hyperOsNativeProxyCandidate;
         this.icon = icon;
     }
 }

--- a/app/src/main/java/com/dpis/module/DpiConfigStore.java
+++ b/app/src/main/java/com/dpis/module/DpiConfigStore.java
@@ -21,6 +21,7 @@ final class DpiConfigStore {
     static final String KEY_FONT_DEBUG_OVERLAY_ENABLED = "font.debug.overlay_enabled";
     static final String KEY_FONT_DEBUG_SELECTED_MODE = "font.debug.selected_mode";
     static final String KEY_FONT_DEBUG_SELECTED_WINDOW = "font.debug.selected_window";
+    static final String KEY_HYPEROS_FLUTTER_FONT_HOOK_ENABLED = "font.hyperos_flutter_hook_enabled";
     static final String KEY_HIDE_LAUNCHER_ICON = "ui.hide_launcher_icon";
     static final String KEY_STARTUP_DISCLAIMER_ACCEPTED = "ui.startup_disclaimer_accepted";
 
@@ -173,6 +174,18 @@ final class DpiConfigStore {
         return commitBoth(editor -> editor.putInt(KEY_FONT_DEBUG_SELECTED_WINDOW, window));
     }
 
+    boolean isHyperOsFlutterFontHookEnabled() {
+        return getBoolean(KEY_HYPEROS_FLUTTER_FONT_HOOK_ENABLED, false);
+    }
+
+    boolean hasHyperOsFlutterFontHookEnabled() {
+        return containsInPrimary(KEY_HYPEROS_FLUTTER_FONT_HOOK_ENABLED);
+    }
+
+    boolean setHyperOsFlutterFontHookEnabled(boolean enabled) {
+        return commitBoth(editor -> editor.putBoolean(KEY_HYPEROS_FLUTTER_FONT_HOOK_ENABLED, enabled));
+    }
+
     int getDebugInt(String key, int defaultValue) {
         return getInt(key, defaultValue);
     }
@@ -313,6 +326,18 @@ final class DpiConfigStore {
         return commitBoth(editor -> editor
                 .putStringSet(KEY_TARGET_PACKAGES, packages)
                 .putBoolean(keyForDpisEnabled(packageName), false));
+    }
+
+    boolean clearTargetPackageConfig(String packageName) {
+        LinkedHashSet<String> packages = new LinkedHashSet<>(getConfiguredPackages());
+        packages.remove(packageName);
+        return commitBoth(editor -> editor
+                .putStringSet(KEY_TARGET_PACKAGES, packages)
+                .remove(keyForViewportWidth(packageName))
+                .remove(keyForViewportMode(packageName))
+                .remove(keyForFontScale(packageName))
+                .remove(keyForFontMode(packageName))
+                .remove(keyForDpisEnabled(packageName)));
     }
 
     boolean ensureSeedConfig(Map<String, Integer> seedTargetViewportWidthDps) {

--- a/app/src/main/java/com/dpis/module/DpisApplication.java
+++ b/app/src/main/java/com/dpis/module/DpisApplication.java
@@ -1,7 +1,6 @@
 package com.dpis.module;
 
 import android.app.Application;
-
 import com.google.android.material.color.DynamicColors;
 
 import java.util.LinkedHashMap;
@@ -28,8 +27,10 @@ public final class DpisApplication extends Application implements XposedServiceH
     public void onCreate() {
         super.onCreate();
         DynamicColors.applyToActivitiesIfAvailable(this);
+        HyperOsNativeProxyAssetExporter.exportBundledNativeProxyLibrary(this);
         configStore = ConfigStoreFactory.createForModuleApp(this);
         DpisLog.setLoggingEnabled(configStore.isGlobalLogEnabled());
+        HyperOsNativeFontPropertySyncer.syncConfiguredFontTargetsAsync(configStore);
         XposedServiceHelper.registerListener(this);
         UpdatePackageInstaller.clearStaleUpdateCache(this, UPDATE_CACHE_STARTUP_MAX_AGE_MS);
     }
@@ -43,6 +44,7 @@ public final class DpisApplication extends Application implements XposedServiceH
         migrateConfig(localStore, remoteStore);
         configStore = remoteStore;
         DpisLog.setLoggingEnabled(remoteStore.isGlobalLogEnabled());
+        HyperOsNativeFontPropertySyncer.syncConfiguredFontTargetsAsync(remoteStore);
         xposedService = service;
         notifyServiceStateChanged();
     }
@@ -51,6 +53,7 @@ public final class DpisApplication extends Application implements XposedServiceH
     public void onServiceDied(XposedService service) {
         configStore = ConfigStoreFactory.createForModuleApp(this);
         DpisLog.setLoggingEnabled(configStore.isGlobalLogEnabled());
+        HyperOsNativeFontPropertySyncer.syncConfiguredFontTargetsAsync(configStore);
         xposedService = null;
         notifyServiceStateChanged();
     }
@@ -84,8 +87,9 @@ public final class DpisApplication extends Application implements XposedServiceH
         if (from == null || to == null || from == to) {
             return;
         }
+        Set<String> localPackages = from.getConfiguredPackages();
         LinkedHashMap<String, Integer> seedViewportWidthDps = new LinkedHashMap<>();
-        for (String packageName : from.getConfiguredPackages()) {
+        for (String packageName : localPackages) {
             Integer viewportWidthDp = from.getTargetViewportWidthDp(packageName);
             if (viewportWidthDp != null && viewportWidthDp > 0) {
                 seedViewportWidthDps.put(packageName, viewportWidthDp);
@@ -94,7 +98,7 @@ public final class DpisApplication extends Application implements XposedServiceH
         if (!seedViewportWidthDps.isEmpty()) {
             to.ensureSeedConfig(seedViewportWidthDps);
         }
-        for (String packageName : from.getConfiguredPackages()) {
+        for (String packageName : localPackages) {
             Integer fontScalePercent = from.getTargetFontScalePercent(packageName);
             if (fontScalePercent != null && fontScalePercent > 0) {
                 if (!to.hasPrimaryTargetFontScalePercent(packageName)) {
@@ -124,6 +128,9 @@ public final class DpisApplication extends Application implements XposedServiceH
         }
         if (from.hasGlobalLogEnabled() && !to.hasGlobalLogEnabled()) {
             to.setGlobalLogEnabled(from.isGlobalLogEnabled());
+        }
+        if (from.hasHyperOsFlutterFontHookEnabled() && !to.hasHyperOsFlutterFontHookEnabled()) {
+            to.setHyperOsFlutterFontHookEnabled(from.isHyperOsFlutterFontHookEnabled());
         }
         if (from.hasLauncherIconHidden() && !to.hasLauncherIconHidden()) {
             to.setLauncherIconHidden(from.isLauncherIconHidden());

--- a/app/src/main/java/com/dpis/module/DpisPackageLifecycleReceiver.java
+++ b/app/src/main/java/com/dpis/module/DpisPackageLifecycleReceiver.java
@@ -1,0 +1,21 @@
+package com.dpis.module;
+
+import android.content.BroadcastReceiver;
+import android.content.Context;
+import android.content.Intent;
+
+public final class DpisPackageLifecycleReceiver extends BroadcastReceiver {
+    @Override
+    public void onReceive(Context context, Intent intent) {
+        if (context == null || intent == null
+                || !Intent.ACTION_MY_PACKAGE_REPLACED.equals(intent.getAction())) {
+            return;
+        }
+        HyperOsNativeProxyAssetExporter.exportBundledNativeProxyLibrary(context);
+        DpiConfigStore store = DpisApplication.getConfigStore();
+        if (store == null) {
+            store = ConfigStoreFactory.createForModuleApp(context);
+        }
+        HyperOsNativeFontPropertySyncer.syncConfiguredFontTargetsAsync(store);
+    }
+}

--- a/app/src/main/java/com/dpis/module/FontDebugLogcatBridge.java
+++ b/app/src/main/java/com/dpis/module/FontDebugLogcatBridge.java
@@ -1,0 +1,100 @@
+package com.dpis.module;
+
+import android.content.Context;
+import android.os.Bundle;
+
+import java.io.BufferedReader;
+import java.io.IOException;
+import java.io.InputStreamReader;
+import java.nio.charset.StandardCharsets;
+import java.util.LinkedHashMap;
+import java.util.Map;
+
+final class FontDebugLogcatBridge {
+    private static final int MAX_LINES = 300;
+    private static final int TOP_LIMIT = 20;
+    private static final String[] MARKERS = {
+            "DPIS_FONT TextPaint.setTextSize override",
+            "DPIS_FONT Paint.setTextSize override",
+            "DPIS_FONT ForceTextSize override",
+            "DPIS_FONT TextView span override",
+            "DPIS_FONT SystemServer config fontScale"
+    };
+
+    private FontDebugLogcatBridge() {
+    }
+
+    static boolean importRecent(Context context) {
+        if (context == null) {
+            return false;
+        }
+        Map<String, Integer> counts = new LinkedHashMap<>();
+        Process process = null;
+        try {
+            process = new ProcessBuilder("logcat", "-d", "-t", String.valueOf(MAX_LINES),
+                    "-s", "DPIS:I", "*:S").redirectErrorStream(true).start();
+            try (BufferedReader reader = new BufferedReader(new InputStreamReader(
+                    process.getInputStream(), StandardCharsets.UTF_8))) {
+                String line;
+                while ((line = reader.readLine()) != null) {
+                    String key = resolveKey(line);
+                    if (key != null) {
+                        counts.put(key, counts.getOrDefault(key, 0) + 1);
+                    }
+                }
+            }
+            process.waitFor();
+        } catch (IOException ignored) {
+            return false;
+        } catch (InterruptedException ignored) {
+            Thread.currentThread().interrupt();
+            return false;
+        } finally {
+            if (process != null) {
+                process.destroy();
+            }
+        }
+        if (counts.isEmpty()) {
+            return true;
+        }
+        String formatted = formatCounts(counts);
+        Bundle extras = new Bundle();
+        extras.putString(FontDebugStatsStore.EXTRA_CHAIN_5S, formatted);
+        extras.putString(FontDebugStatsStore.EXTRA_CHAIN_30S, formatted);
+        extras.putString(FontDebugStatsStore.EXTRA_CHAIN_ALL, formatted);
+        extras.putInt(FontDebugStatsStore.EXTRA_EVENT_TOTAL,
+                counts.values().stream().mapToInt(Integer::intValue).sum());
+        extras.putLong(FontDebugStatsStore.EXTRA_UPDATED_AT, System.currentTimeMillis());
+        FontDebugStatsUpdateWriter.applyExtras(context, extras);
+        return true;
+    }
+
+    private static String resolveKey(String line) {
+        if (line == null) {
+            return null;
+        }
+        for (String marker : MARKERS) {
+            int index = line.indexOf(marker);
+            if (index >= 0) {
+                return marker.replace("DPIS_FONT ", "").replace(" override", "");
+            }
+        }
+        return null;
+    }
+
+    private static String formatCounts(Map<String, Integer> counts) {
+        StringBuilder builder = new StringBuilder();
+        int emitted = 0;
+        for (Map.Entry<String, Integer> entry : counts.entrySet()) {
+            if (emitted > 0) {
+                builder.append('\n');
+            }
+            builder.append(entry.getValue()).append(' ').append(entry.getKey());
+            emitted++;
+            if (emitted >= TOP_LIMIT) {
+                break;
+            }
+        }
+        return builder.toString();
+    }
+}

--- a/app/src/main/java/com/dpis/module/FontDebugOverlayService.java
+++ b/app/src/main/java/com/dpis/module/FontDebugOverlayService.java
@@ -6,6 +6,7 @@ import android.graphics.Color;
 import android.graphics.PixelFormat;
 import android.graphics.drawable.GradientDrawable;
 import android.os.Handler;
+import android.os.HandlerThread;
 import android.os.IBinder;
 import android.os.Looper;
 import android.provider.Settings;
@@ -25,6 +26,9 @@ import java.util.regex.Pattern;
 
 public final class FontDebugOverlayService extends Service {
     private static final long REFRESH_INTERVAL_MS = 500L;
+    private static final long BRIDGE_IMPORT_INTERVAL_MS = 2_000L;
+    private static final long LOGCAT_IMPORT_INTERVAL_MS = 5_000L;
+    private static final long LOGCAT_FAILURE_RETRY_MS = 30_000L;
     private static final long WINDOW_5S_STALE_MS = 5_000L;
     private static final long WINDOW_30S_STALE_MS = 30_000L;
     private static final Pattern UNIT_LINE_PATTERN =
@@ -33,11 +37,22 @@ public final class FontDebugOverlayService extends Service {
             Pattern.compile("^视口\\s+([^|\\s]+).*");
 
     private final Handler handler = new Handler(Looper.getMainLooper());
+    private HandlerThread bridgeThread;
+    private Handler bridgeHandler;
+    private volatile long lastBridgeImportAt;
+    private volatile long lastLogcatImportAt;
+    private volatile boolean bridgeImportRunning;
     private final Runnable refreshRunnable = new Runnable() {
         @Override
         public void run() {
             renderOverlayText();
             handler.postDelayed(this, REFRESH_INTERVAL_MS);
+        }
+    };
+    private final Runnable bridgeImportRunnable = new Runnable() {
+        @Override
+        public void run() {
+            importDebugDataInBackground();
         }
     };
 
@@ -66,6 +81,9 @@ public final class FontDebugOverlayService extends Service {
             stopSelf();
             return;
         }
+        bridgeThread = new HandlerThread("DPIS-font-debug-bridge");
+        bridgeThread.start();
+        bridgeHandler = new Handler(bridgeThread.getLooper());
         createOverlayView();
         handler.post(refreshRunnable);
     }
@@ -85,6 +103,14 @@ public final class FontDebugOverlayService extends Service {
     @Override
     public void onDestroy() {
         handler.removeCallbacks(refreshRunnable);
+        if (bridgeHandler != null) {
+            bridgeHandler.removeCallbacksAndMessages(null);
+            bridgeHandler = null;
+        }
+        if (bridgeThread != null) {
+            bridgeThread.quitSafely();
+            bridgeThread = null;
+        }
         if (windowManager != null && overlayRoot != null) {
             try {
                 windowManager.removeView(overlayRoot);
@@ -171,6 +197,7 @@ public final class FontDebugOverlayService extends Service {
         if (overlayTextView == null) {
             return;
         }
+        scheduleBridgeImportIfNeeded();
         android.content.SharedPreferences preferences = FontDebugStatsStore.getPreferences(this);
         int eventTotal = preferences.getInt(FontDebugStatsStore.KEY_EVENT_TOTAL, 0);
         long updatedAt = preferences.getLong(FontDebugStatsStore.KEY_UPDATED_AT, 0L);
@@ -252,6 +279,41 @@ public final class FontDebugOverlayService extends Service {
             }
         }
         overlayTextView.setText(body);
+    }
+
+    private void scheduleBridgeImportIfNeeded() {
+        Handler backgroundHandler = bridgeHandler;
+        if (backgroundHandler == null || bridgeImportRunning) {
+            return;
+        }
+        long now = System.currentTimeMillis();
+        if (now - lastBridgeImportAt < BRIDGE_IMPORT_INTERVAL_MS
+                && now - lastLogcatImportAt < LOGCAT_IMPORT_INTERVAL_MS) {
+            return;
+        }
+        bridgeImportRunning = true;
+        backgroundHandler.post(bridgeImportRunnable);
+    }
+
+    private void importDebugDataInBackground() {
+        long now = System.currentTimeMillis();
+        try {
+            if (now - lastBridgeImportAt >= BRIDGE_IMPORT_INTERVAL_MS) {
+                FontDebugStatsFileBridge.importIfNewer(this);
+                lastBridgeImportAt = now;
+            }
+            if (now - lastLogcatImportAt >= LOGCAT_IMPORT_INTERVAL_MS) {
+                boolean imported = FontDebugLogcatBridge.importRecent(this);
+                lastLogcatImportAt = imported ? now : now + LOGCAT_FAILURE_RETRY_MS - LOGCAT_IMPORT_INTERVAL_MS;
+            }
+        } finally {
+            handler.post(new Runnable() {
+                @Override
+                public void run() {
+                    bridgeImportRunning = false;
+                }
+            });
+        }
     }
 
     private String resolveFontModeText(String viewportSummary) {

--- a/app/src/main/java/com/dpis/module/FontDebugStatsFileBridge.java
+++ b/app/src/main/java/com/dpis/module/FontDebugStatsFileBridge.java
@@ -1,0 +1,150 @@
+package com.dpis.module;
+
+import android.content.Context;
+import android.content.SharedPreferences;
+import android.os.Bundle;
+import android.os.Environment;
+
+import java.io.File;
+import java.io.FileInputStream;
+import java.io.FileOutputStream;
+import java.io.IOException;
+import java.util.Properties;
+
+final class FontDebugStatsFileBridge {
+    private static final String DIR_NAME = "DPIS";
+    private static final String FILE_NAME = "font_debug_stats.properties";
+
+    private FontDebugStatsFileBridge() {
+    }
+
+    static void write(Bundle extras) {
+        File file = resolveFile();
+        if (file == null || extras == null || extras.isEmpty()) {
+            return;
+        }
+        File parent = file.getParentFile();
+        if (parent == null || (!parent.exists() && !parent.mkdirs())) {
+            return;
+        }
+        Properties properties = new Properties();
+        putString(properties, extras, FontDebugStatsStore.EXTRA_CHAIN_5S);
+        putString(properties, extras, FontDebugStatsStore.EXTRA_CHAIN_30S);
+        putString(properties, extras, FontDebugStatsStore.EXTRA_CHAIN_ALL);
+        putString(properties, extras, FontDebugStatsStore.EXTRA_CHAIN_VIEW_5S);
+        putString(properties, extras, FontDebugStatsStore.EXTRA_CHAIN_VIEW_30S);
+        putString(properties, extras, FontDebugStatsStore.EXTRA_CHAIN_VIEW_ALL);
+        putString(properties, extras, FontDebugStatsStore.EXTRA_UNIT_BREAKDOWN_5S);
+        putString(properties, extras, FontDebugStatsStore.EXTRA_VIEWPORT_DEBUG_SUMMARY);
+        if (extras.containsKey(FontDebugStatsStore.EXTRA_EVENT_TOTAL)) {
+            properties.setProperty(FontDebugStatsStore.EXTRA_EVENT_TOTAL,
+                    String.valueOf(extras.getInt(FontDebugStatsStore.EXTRA_EVENT_TOTAL, 0)));
+        }
+        if (extras.containsKey(FontDebugStatsStore.EXTRA_UPDATED_AT)) {
+            properties.setProperty(FontDebugStatsStore.EXTRA_UPDATED_AT,
+                    String.valueOf(extras.getLong(FontDebugStatsStore.EXTRA_UPDATED_AT, 0L)));
+        }
+        try (FileOutputStream output = new FileOutputStream(file)) {
+            properties.store(output, null);
+        } catch (IOException ignored) {
+        }
+    }
+
+    static void importIfNewer(Context context) {
+        File file = resolveFile();
+        if (context == null || file == null || !file.isFile()) {
+            return;
+        }
+        Properties properties = new Properties();
+        try (FileInputStream input = new FileInputStream(file)) {
+            properties.load(input);
+        } catch (IOException ignored) {
+            return;
+        }
+        importIfNewer(FontDebugStatsStore.getPreferences(context), properties);
+    }
+
+    static void importIfNewer(SharedPreferences preferences, Properties properties) {
+        if (preferences == null || properties == null || properties.isEmpty()) {
+            return;
+        }
+        long incomingUpdatedAt = parseLong(properties.getProperty(FontDebugStatsStore.EXTRA_UPDATED_AT), 0L);
+        long currentUpdatedAt = preferences.getLong(FontDebugStatsStore.KEY_UPDATED_AT, 0L);
+        if (incomingUpdatedAt <= 0L || incomingUpdatedAt <= currentUpdatedAt) {
+            return;
+        }
+        SharedPreferences.Editor editor = preferences.edit();
+        copyString(properties, editor, FontDebugStatsStore.EXTRA_CHAIN_5S,
+                FontDebugStatsStore.KEY_CHAIN_5S);
+        copyString(properties, editor, FontDebugStatsStore.EXTRA_CHAIN_30S,
+                FontDebugStatsStore.KEY_CHAIN_30S);
+        copyString(properties, editor, FontDebugStatsStore.EXTRA_CHAIN_ALL,
+                FontDebugStatsStore.KEY_CHAIN_ALL);
+        copyString(properties, editor, FontDebugStatsStore.EXTRA_CHAIN_VIEW_5S,
+                FontDebugStatsStore.KEY_CHAIN_VIEW_5S);
+        copyString(properties, editor, FontDebugStatsStore.EXTRA_CHAIN_VIEW_30S,
+                FontDebugStatsStore.KEY_CHAIN_VIEW_30S);
+        copyString(properties, editor, FontDebugStatsStore.EXTRA_CHAIN_VIEW_ALL,
+                FontDebugStatsStore.KEY_CHAIN_VIEW_ALL);
+        copyString(properties, editor, FontDebugStatsStore.EXTRA_UNIT_BREAKDOWN_5S,
+                FontDebugStatsStore.KEY_UNIT_BREAKDOWN_5S);
+        copyString(properties, editor, FontDebugStatsStore.EXTRA_VIEWPORT_DEBUG_SUMMARY,
+                FontDebugStatsStore.KEY_VIEWPORT_DEBUG_SUMMARY);
+        copyInt(properties, editor, FontDebugStatsStore.EXTRA_EVENT_TOTAL,
+                FontDebugStatsStore.KEY_EVENT_TOTAL);
+        editor.putLong(FontDebugStatsStore.KEY_UPDATED_AT, incomingUpdatedAt);
+        editor.apply();
+    }
+
+    private static File resolveFile() {
+        File downloads = Environment.getExternalStoragePublicDirectory(Environment.DIRECTORY_DOWNLOADS);
+        if (downloads == null) {
+            return null;
+        }
+        return new File(new File(downloads, DIR_NAME), FILE_NAME);
+    }
+
+    private static void putString(Properties properties, Bundle extras, String key) {
+        if (extras.containsKey(key)) {
+            String value = extras.getString(key);
+            if (value != null) {
+                properties.setProperty(key, value);
+            }
+        }
+    }
+
+    private static void copyString(Properties properties,
+                                   SharedPreferences.Editor editor,
+                                   String propertyKey,
+                                   String preferenceKey) {
+        String value = properties.getProperty(propertyKey);
+        if (value != null) {
+            editor.putString(preferenceKey, value);
+        }
+    }
+
+    private static void copyInt(Properties properties,
+                                SharedPreferences.Editor editor,
+                                String propertyKey,
+                                String preferenceKey) {
+        String value = properties.getProperty(propertyKey);
+        if (value == null) {
+            return;
+        }
+        try {
+            editor.putInt(preferenceKey, Integer.parseInt(value));
+        } catch (NumberFormatException ignored) {
+        }
+    }
+
+    private static long parseLong(String value, long fallback) {
+        if (value == null) {
+            return fallback;
+        }
+        try {
+            return Long.parseLong(value);
+        } catch (NumberFormatException ignored) {
+            return fallback;
+        }
+    }
+}

--- a/app/src/main/java/com/dpis/module/FontDebugStatsIngestActivity.java
+++ b/app/src/main/java/com/dpis/module/FontDebugStatsIngestActivity.java
@@ -1,0 +1,14 @@
+package com.dpis.module;
+
+import android.app.Activity;
+import android.os.Bundle;
+
+public final class FontDebugStatsIngestActivity extends Activity {
+    @Override
+    protected void onCreate(Bundle savedInstanceState) {
+        super.onCreate(savedInstanceState);
+        FontDebugStatsUpdateWriter.applyExtras(this, getIntent() == null ? null : getIntent().getExtras());
+        finish();
+        overridePendingTransition(0, 0);
+    }
+}

--- a/app/src/main/java/com/dpis/module/FontDebugStatsIngestService.java
+++ b/app/src/main/java/com/dpis/module/FontDebugStatsIngestService.java
@@ -1,0 +1,24 @@
+package com.dpis.module;
+
+import android.app.Service;
+import android.content.Intent;
+import android.os.IBinder;
+
+import androidx.annotation.Nullable;
+
+public final class FontDebugStatsIngestService extends Service {
+    @Override
+    public int onStartCommand(Intent intent, int flags, int startId) {
+        if (intent != null) {
+            FontDebugStatsUpdateWriter.applyExtras(this, intent.getExtras());
+        }
+        stopSelf(startId);
+        return START_NOT_STICKY;
+    }
+
+    @Nullable
+    @Override
+    public IBinder onBind(Intent intent) {
+        return null;
+    }
+}

--- a/app/src/main/java/com/dpis/module/FontDebugStatsProvider.java
+++ b/app/src/main/java/com/dpis/module/FontDebugStatsProvider.java
@@ -1,0 +1,67 @@
+package com.dpis.module;
+
+import android.content.ContentProvider;
+import android.content.ContentValues;
+import android.database.Cursor;
+import android.net.Uri;
+import android.os.Bundle;
+
+import androidx.annotation.NonNull;
+import androidx.annotation.Nullable;
+
+public final class FontDebugStatsProvider extends ContentProvider {
+    static final String METHOD_APPLY_UPDATE = "apply_update";
+    static final String AUTHORITY_SUFFIX = ".fontdebugstats";
+
+    @Override
+    public boolean onCreate() {
+        return true;
+    }
+
+    @Nullable
+    @Override
+    public Bundle call(@NonNull String method, @Nullable String arg, @Nullable Bundle extras) {
+        if (!METHOD_APPLY_UPDATE.equals(method)) {
+            return super.call(method, arg, extras);
+        }
+        FontDebugStatsUpdateWriter.applyExtras(getContext(), extras);
+        return Bundle.EMPTY;
+    }
+
+    @Nullable
+    @Override
+    public Cursor query(@NonNull Uri uri,
+                        @Nullable String[] projection,
+                        @Nullable String selection,
+                        @Nullable String[] selectionArgs,
+                        @Nullable String sortOrder) {
+        return null;
+    }
+
+    @Nullable
+    @Override
+    public String getType(@NonNull Uri uri) {
+        return null;
+    }
+
+    @Nullable
+    @Override
+    public Uri insert(@NonNull Uri uri, @Nullable ContentValues values) {
+        return null;
+    }
+
+    @Override
+    public int delete(@NonNull Uri uri,
+                      @Nullable String selection,
+                      @Nullable String[] selectionArgs) {
+        return 0;
+    }
+
+    @Override
+    public int update(@NonNull Uri uri,
+                      @Nullable ContentValues values,
+                      @Nullable String selection,
+                      @Nullable String[] selectionArgs) {
+        return 0;
+    }
+}

--- a/app/src/main/java/com/dpis/module/FontDebugStatsReceiver.java
+++ b/app/src/main/java/com/dpis/module/FontDebugStatsReceiver.java
@@ -3,7 +3,6 @@ package com.dpis.module;
 import android.content.BroadcastReceiver;
 import android.content.Context;
 import android.content.Intent;
-import android.content.SharedPreferences;
 
 public final class FontDebugStatsReceiver extends BroadcastReceiver {
     @Override
@@ -14,48 +13,6 @@ public final class FontDebugStatsReceiver extends BroadcastReceiver {
         if (!FontDebugStatsStore.ACTION_STATS_UPDATE.equals(intent.getAction())) {
             return;
         }
-        SharedPreferences preferences = FontDebugStatsStore.getPreferences(context);
-        SharedPreferences.Editor editor = preferences.edit();
-        if (intent.hasExtra(FontDebugStatsStore.EXTRA_CHAIN_5S)) {
-            editor.putString(FontDebugStatsStore.KEY_CHAIN_5S,
-                    intent.getStringExtra(FontDebugStatsStore.EXTRA_CHAIN_5S));
-        }
-        if (intent.hasExtra(FontDebugStatsStore.EXTRA_CHAIN_30S)) {
-            editor.putString(FontDebugStatsStore.KEY_CHAIN_30S,
-                    intent.getStringExtra(FontDebugStatsStore.EXTRA_CHAIN_30S));
-        }
-        if (intent.hasExtra(FontDebugStatsStore.EXTRA_CHAIN_ALL)) {
-            editor.putString(FontDebugStatsStore.KEY_CHAIN_ALL,
-                    intent.getStringExtra(FontDebugStatsStore.EXTRA_CHAIN_ALL));
-        }
-        if (intent.hasExtra(FontDebugStatsStore.EXTRA_CHAIN_VIEW_5S)) {
-            editor.putString(FontDebugStatsStore.KEY_CHAIN_VIEW_5S,
-                    intent.getStringExtra(FontDebugStatsStore.EXTRA_CHAIN_VIEW_5S));
-        }
-        if (intent.hasExtra(FontDebugStatsStore.EXTRA_CHAIN_VIEW_30S)) {
-            editor.putString(FontDebugStatsStore.KEY_CHAIN_VIEW_30S,
-                    intent.getStringExtra(FontDebugStatsStore.EXTRA_CHAIN_VIEW_30S));
-        }
-        if (intent.hasExtra(FontDebugStatsStore.EXTRA_CHAIN_VIEW_ALL)) {
-            editor.putString(FontDebugStatsStore.KEY_CHAIN_VIEW_ALL,
-                    intent.getStringExtra(FontDebugStatsStore.EXTRA_CHAIN_VIEW_ALL));
-        }
-        if (intent.hasExtra(FontDebugStatsStore.EXTRA_EVENT_TOTAL)) {
-            editor.putInt(FontDebugStatsStore.KEY_EVENT_TOTAL,
-                    intent.getIntExtra(FontDebugStatsStore.EXTRA_EVENT_TOTAL, 0));
-        }
-        if (intent.hasExtra(FontDebugStatsStore.EXTRA_UPDATED_AT)) {
-            editor.putLong(FontDebugStatsStore.KEY_UPDATED_AT,
-                    intent.getLongExtra(FontDebugStatsStore.EXTRA_UPDATED_AT, 0L));
-        }
-        if (intent.hasExtra(FontDebugStatsStore.EXTRA_UNIT_BREAKDOWN_5S)) {
-            editor.putString(FontDebugStatsStore.KEY_UNIT_BREAKDOWN_5S,
-                    intent.getStringExtra(FontDebugStatsStore.EXTRA_UNIT_BREAKDOWN_5S));
-        }
-        if (intent.hasExtra(FontDebugStatsStore.EXTRA_VIEWPORT_DEBUG_SUMMARY)) {
-            editor.putString(FontDebugStatsStore.KEY_VIEWPORT_DEBUG_SUMMARY,
-                    intent.getStringExtra(FontDebugStatsStore.EXTRA_VIEWPORT_DEBUG_SUMMARY));
-        }
-        editor.apply();
+        FontDebugStatsUpdateWriter.applyExtras(context, intent.getExtras());
     }
 }

--- a/app/src/main/java/com/dpis/module/FontDebugStatsReporter.java
+++ b/app/src/main/java/com/dpis/module/FontDebugStatsReporter.java
@@ -2,7 +2,7 @@ package com.dpis.module;
 
 import android.app.Application;
 import android.content.Context;
-import android.content.Intent;
+import android.os.Bundle;
 
 import java.lang.reflect.Method;
 import java.util.ArrayDeque;
@@ -197,23 +197,17 @@ final class FontDebugStatsReporter {
         if (context == null || snapshot == null) {
             return;
         }
-        Intent intent = new Intent(FontDebugStatsStore.ACTION_STATS_UPDATE);
-        // Hook callbacks execute inside target app processes; always route updates
-        // back to the module package receiver instead of target app package.
-        intent.setPackage(BuildConfig.APPLICATION_ID);
-        intent.putExtra(FontDebugStatsStore.EXTRA_CHAIN_5S, snapshot.chain5s);
-        intent.putExtra(FontDebugStatsStore.EXTRA_CHAIN_30S, snapshot.chain30s);
-        intent.putExtra(FontDebugStatsStore.EXTRA_CHAIN_ALL, snapshot.chainAll);
-        intent.putExtra(FontDebugStatsStore.EXTRA_CHAIN_VIEW_5S, snapshot.chainView5s);
-        intent.putExtra(FontDebugStatsStore.EXTRA_CHAIN_VIEW_30S, snapshot.chainView30s);
-        intent.putExtra(FontDebugStatsStore.EXTRA_CHAIN_VIEW_ALL, snapshot.chainViewAll);
-        intent.putExtra(FontDebugStatsStore.EXTRA_UNIT_BREAKDOWN_5S, snapshot.unitBreakdown5s);
-        intent.putExtra(FontDebugStatsStore.EXTRA_EVENT_TOTAL, snapshot.eventTotal);
-        intent.putExtra(FontDebugStatsStore.EXTRA_UPDATED_AT, snapshot.updatedAt);
-        try {
-            context.sendBroadcast(intent);
-        } catch (Throwable ignored) {
-        }
+        Bundle extras = new Bundle();
+        extras.putString(FontDebugStatsStore.EXTRA_CHAIN_5S, snapshot.chain5s);
+        extras.putString(FontDebugStatsStore.EXTRA_CHAIN_30S, snapshot.chain30s);
+        extras.putString(FontDebugStatsStore.EXTRA_CHAIN_ALL, snapshot.chainAll);
+        extras.putString(FontDebugStatsStore.EXTRA_CHAIN_VIEW_5S, snapshot.chainView5s);
+        extras.putString(FontDebugStatsStore.EXTRA_CHAIN_VIEW_30S, snapshot.chainView30s);
+        extras.putString(FontDebugStatsStore.EXTRA_CHAIN_VIEW_ALL, snapshot.chainViewAll);
+        extras.putString(FontDebugStatsStore.EXTRA_UNIT_BREAKDOWN_5S, snapshot.unitBreakdown5s);
+        extras.putInt(FontDebugStatsStore.EXTRA_EVENT_TOTAL, snapshot.eventTotal);
+        extras.putLong(FontDebugStatsStore.EXTRA_UPDATED_AT, snapshot.updatedAt);
+        FontDebugStatsTransport.sendUpdate(context, extras);
     }
 
     private static void increment(Map<String, Integer> map, String key) {

--- a/app/src/main/java/com/dpis/module/FontDebugStatsTransport.java
+++ b/app/src/main/java/com/dpis/module/FontDebugStatsTransport.java
@@ -1,0 +1,91 @@
+package com.dpis.module;
+
+import android.content.Context;
+import android.content.ComponentName;
+import android.content.Intent;
+import android.content.SharedPreferences;
+import android.net.Uri;
+import android.os.Bundle;
+
+import io.github.libxposed.api.XposedInterface;
+
+final class FontDebugStatsTransport {
+    private static final String MODULE_CLASS_PACKAGE = "com.dpis.module";
+    private static volatile SharedPreferences remotePreferences;
+
+    private FontDebugStatsTransport() {
+    }
+
+    static void initialize(XposedInterface xposed) {
+        if (xposed == null) {
+            return;
+        }
+        try {
+            remotePreferences = xposed.getRemotePreferences(DpiConfigStore.GROUP);
+        } catch (Throwable ignored) {
+            remotePreferences = null;
+        }
+    }
+
+    static void sendUpdate(Context context, Bundle extras) {
+        if (extras == null || extras.isEmpty()) {
+            return;
+        }
+        SharedPreferences preferences = remotePreferences;
+        if (preferences != null) {
+            try {
+                FontDebugStatsUpdateWriter.applyExtras(preferences, extras);
+            } catch (Throwable throwable) {
+                DpisLog.e("font debug remote preferences update failed", throwable);
+            }
+        }
+        if (context == null) {
+            return;
+        }
+        try {
+            context.getContentResolver().call(buildUri(),
+                    FontDebugStatsProvider.METHOD_APPLY_UPDATE, null, extras);
+        } catch (Throwable throwable) {
+            DpisLog.e("font debug provider update failed", throwable);
+        }
+        try {
+            Intent intent = new Intent(FontDebugStatsStore.ACTION_STATS_UPDATE);
+            intent.setComponent(new ComponentName(BuildConfig.APPLICATION_ID,
+                    MODULE_CLASS_PACKAGE + ".FontDebugStatsReceiver"));
+            intent.addFlags(Intent.FLAG_RECEIVER_FOREGROUND);
+            intent.putExtras(extras);
+            context.sendBroadcast(intent);
+        } catch (Throwable throwable) {
+            DpisLog.e("font debug explicit broadcast update failed", throwable);
+        }
+        try {
+            Intent intent = new Intent();
+            intent.setComponent(new ComponentName(BuildConfig.APPLICATION_ID,
+                    MODULE_CLASS_PACKAGE + ".FontDebugStatsIngestService"));
+            intent.putExtras(extras);
+            context.startService(intent);
+        } catch (Throwable throwable) {
+            DpisLog.e("font debug ingest service update failed", throwable);
+        }
+        try {
+            Intent intent = new Intent();
+            intent.setComponent(new ComponentName(BuildConfig.APPLICATION_ID,
+                    MODULE_CLASS_PACKAGE + ".FontDebugStatsIngestActivity"));
+            intent.addFlags(Intent.FLAG_ACTIVITY_NEW_TASK
+                    | Intent.FLAG_ACTIVITY_NO_ANIMATION
+                    | Intent.FLAG_ACTIVITY_EXCLUDE_FROM_RECENTS);
+            intent.putExtras(extras);
+            context.startActivity(intent);
+        } catch (Throwable throwable) {
+            DpisLog.e("font debug ingest activity update failed", throwable);
+        }
+        FontDebugStatsFileBridge.write(extras);
+    }
+
+    private static Uri buildUri() {
+        return new Uri.Builder()
+                .scheme("content")
+                .authority(BuildConfig.APPLICATION_ID + FontDebugStatsProvider.AUTHORITY_SUFFIX)
+                .build();
+    }
+}

--- a/app/src/main/java/com/dpis/module/FontDebugStatsUpdateWriter.java
+++ b/app/src/main/java/com/dpis/module/FontDebugStatsUpdateWriter.java
@@ -1,0 +1,59 @@
+package com.dpis.module;
+
+import android.content.Context;
+import android.content.SharedPreferences;
+import android.os.Bundle;
+
+final class FontDebugStatsUpdateWriter {
+    private FontDebugStatsUpdateWriter() {
+    }
+
+    static void applyExtras(Context context, Bundle extras) {
+        if (context == null || extras == null || extras.isEmpty()) {
+            return;
+        }
+        SharedPreferences preferences = FontDebugStatsStore.getPreferences(context);
+        applyExtras(preferences, extras);
+    }
+
+    static void applyExtras(SharedPreferences preferences, Bundle extras) {
+        if (preferences == null || extras == null || extras.isEmpty()) {
+            return;
+        }
+        SharedPreferences.Editor editor = preferences.edit();
+        putStringIfPresent(editor, extras, FontDebugStatsStore.EXTRA_CHAIN_5S,
+                FontDebugStatsStore.KEY_CHAIN_5S);
+        putStringIfPresent(editor, extras, FontDebugStatsStore.EXTRA_CHAIN_30S,
+                FontDebugStatsStore.KEY_CHAIN_30S);
+        putStringIfPresent(editor, extras, FontDebugStatsStore.EXTRA_CHAIN_ALL,
+                FontDebugStatsStore.KEY_CHAIN_ALL);
+        putStringIfPresent(editor, extras, FontDebugStatsStore.EXTRA_CHAIN_VIEW_5S,
+                FontDebugStatsStore.KEY_CHAIN_VIEW_5S);
+        putStringIfPresent(editor, extras, FontDebugStatsStore.EXTRA_CHAIN_VIEW_30S,
+                FontDebugStatsStore.KEY_CHAIN_VIEW_30S);
+        putStringIfPresent(editor, extras, FontDebugStatsStore.EXTRA_CHAIN_VIEW_ALL,
+                FontDebugStatsStore.KEY_CHAIN_VIEW_ALL);
+        putStringIfPresent(editor, extras, FontDebugStatsStore.EXTRA_UNIT_BREAKDOWN_5S,
+                FontDebugStatsStore.KEY_UNIT_BREAKDOWN_5S);
+        putStringIfPresent(editor, extras, FontDebugStatsStore.EXTRA_VIEWPORT_DEBUG_SUMMARY,
+                FontDebugStatsStore.KEY_VIEWPORT_DEBUG_SUMMARY);
+        if (extras.containsKey(FontDebugStatsStore.EXTRA_EVENT_TOTAL)) {
+            editor.putInt(FontDebugStatsStore.KEY_EVENT_TOTAL,
+                    extras.getInt(FontDebugStatsStore.EXTRA_EVENT_TOTAL, 0));
+        }
+        if (extras.containsKey(FontDebugStatsStore.EXTRA_UPDATED_AT)) {
+            editor.putLong(FontDebugStatsStore.KEY_UPDATED_AT,
+                    extras.getLong(FontDebugStatsStore.EXTRA_UPDATED_AT, 0L));
+        }
+        editor.apply();
+    }
+
+    private static void putStringIfPresent(SharedPreferences.Editor editor,
+                                           Bundle extras,
+                                           String extraKey,
+                                           String preferenceKey) {
+        if (extras.containsKey(extraKey)) {
+            editor.putString(preferenceKey, extras.getString(extraKey));
+        }
+    }
+}

--- a/app/src/main/java/com/dpis/module/HyperOsFlutterFontBridge.java
+++ b/app/src/main/java/com/dpis/module/HyperOsFlutterFontBridge.java
@@ -1,0 +1,89 @@
+package com.dpis.module;
+
+import java.lang.reflect.Method;
+import java.util.Locale;
+
+final class HyperOsFlutterFontBridge {
+    private static final String PROPERTY_PREFIX = "debug.dpis.font.";
+    private static final String FORCE_PROPERTY_PREFIX = "debug.dpis.forcefont.";
+    private static final String RUST_BINARY_PROPERTY_PREFIX = "debug.dpis.rustbin.";
+
+    private HyperOsFlutterFontBridge() {
+    }
+
+    static String propertyNameForPackage(String packageName) {
+        return PROPERTY_PREFIX + String.format(Locale.US, "%08x", packageName.hashCode());
+    }
+
+    static String forcePropertyNameForPackage(String packageName) {
+        return FORCE_PROPERTY_PREFIX + String.format(Locale.US, "%08x", packageName.hashCode());
+    }
+
+    static String rustBinaryPropertyNameForPackage(String packageName) {
+        return RUST_BINARY_PROPERTY_PREFIX + String.format(Locale.US, "%08x", packageName.hashCode());
+    }
+
+    static void publishTarget(String packageName, PerAppDisplayConfig config) {
+        if (packageName == null || packageName.isEmpty() || config == null
+                || !config.hyperOsFlutterFontHookEnabled
+                || config.targetFontScalePercent == null
+                || config.targetFontScalePercent <= 0) {
+            if (shouldClearOnPublishTargetSkip(packageName, config)) {
+                clearTarget(packageName);
+            }
+            return;
+        }
+        setSystemProperty(propertyNameForPackage(packageName),
+                String.valueOf(config.targetFontScalePercent));
+    }
+
+    static void publishRustProxyTarget(String packageName, PerAppDisplayConfig config) {
+        if (packageName == null || packageName.isEmpty() || config == null
+                || config.targetFontScalePercent == null
+                || config.targetFontScalePercent <= 0) {
+            clearTarget(packageName);
+            return;
+        }
+        setSystemProperty(propertyNameForPackage(packageName),
+                String.valueOf(config.targetFontScalePercent));
+    }
+
+    static void clearTarget(String packageName) {
+        if (packageName == null || packageName.isEmpty()) {
+            return;
+        }
+        setSystemProperty(propertyNameForPackage(packageName), "0");
+        setSystemProperty(forcePropertyNameForPackage(packageName), "0");
+        setSystemProperty(rustBinaryPropertyNameForPackage(packageName), "0");
+    }
+
+    static boolean shouldClearOnPublishTargetSkipForTest(String packageName,
+                                                        PerAppDisplayConfig config) {
+        return shouldClearOnPublishTargetSkip(packageName, config);
+    }
+
+    private static boolean shouldClearOnPublishTargetSkip(String packageName,
+                                                         PerAppDisplayConfig config) {
+        return packageName == null || packageName.isEmpty() || config == null
+                || config.targetFontScalePercent == null
+                || config.targetFontScalePercent <= 0;
+    }
+
+    static void publishRustBinaryPath(String packageName, String binaryPath) {
+        if (packageName == null || packageName.isEmpty()
+                || binaryPath == null || binaryPath.isEmpty()) {
+            return;
+        }
+        setSystemProperty(rustBinaryPropertyNameForPackage(packageName), binaryPath);
+    }
+
+    private static void setSystemProperty(String key, String value) {
+        try {
+            Class<?> systemProperties = Class.forName("android.os.SystemProperties");
+            Method set = systemProperties.getDeclaredMethod("set", String.class, String.class);
+            set.invoke(null, key, value);
+        } catch (Throwable throwable) {
+            DpisLog.e("DPIS_FONT HyperOS Flutter property publish failed: key=" + key, throwable);
+        }
+    }
+}

--- a/app/src/main/java/com/dpis/module/HyperOsFlutterFontHookInstaller.java
+++ b/app/src/main/java/com/dpis/module/HyperOsFlutterFontHookInstaller.java
@@ -1,0 +1,27 @@
+package com.dpis.module;
+
+final class HyperOsFlutterFontHookInstaller {
+    private HyperOsFlutterFontHookInstaller() {
+    }
+
+    static void install(String packageName, DpiConfigStore store) {
+        if (store == null || !store.isHyperOsFlutterFontHookEnabled()) {
+            return;
+        }
+        Integer targetFontScalePercent = store.getTargetFontScalePercent(packageName);
+        if (targetFontScalePercent == null || targetFontScalePercent <= 0) {
+            return;
+        }
+        try {
+            System.loadLibrary("dpis_native");
+            configure(packageName, targetFontScalePercent, true);
+            DpisLog.i("DPIS_FONT HyperOS Flutter native hook configured: package="
+                    + packageName + ", targetFontScalePercent=" + targetFontScalePercent);
+        } catch (Throwable throwable) {
+            DpisLog.e("DPIS_FONT HyperOS Flutter native hook configure failed: package="
+                    + packageName, throwable);
+        }
+    }
+
+    private static native void configure(String packageName, int targetFontScalePercent, boolean enabled);
+}

--- a/app/src/main/java/com/dpis/module/HyperOsFlutterFontHookInstaller.java
+++ b/app/src/main/java/com/dpis/module/HyperOsFlutterFontHookInstaller.java
@@ -12,6 +12,10 @@ final class HyperOsFlutterFontHookInstaller {
         if (targetFontScalePercent == null || targetFontScalePercent <= 0) {
             return;
         }
+        String targetFontMode = store.getTargetFontApplyMode(packageName);
+        if (!FontApplyMode.isEnabled(targetFontMode)) {
+            return;
+        }
         try {
             System.loadLibrary("dpis_native");
             configure(packageName, targetFontScalePercent, true);

--- a/app/src/main/java/com/dpis/module/HyperOsNativeAppDetector.java
+++ b/app/src/main/java/com/dpis/module/HyperOsNativeAppDetector.java
@@ -1,0 +1,22 @@
+package com.dpis.module;
+
+import android.content.pm.ApplicationInfo;
+import android.os.Bundle;
+
+final class HyperOsNativeAppDetector {
+    private HyperOsNativeAppDetector() {
+    }
+
+    static boolean isNativeProxyCandidate(ApplicationInfo applicationInfo) {
+        if (applicationInfo == null) {
+            return false;
+        }
+        Bundle metaData = applicationInfo.metaData;
+        if (metaData == null) {
+            return false;
+        }
+        return metaData.getBoolean("hyperos_package", false)
+                || metaData.containsKey("hyperos_app_lib_name")
+                || metaData.containsKey("hyperos_application_entry");
+    }
+}

--- a/app/src/main/java/com/dpis/module/HyperOsNativeFontPropertySyncer.java
+++ b/app/src/main/java/com/dpis/module/HyperOsNativeFontPropertySyncer.java
@@ -1,0 +1,97 @@
+package com.dpis.module;
+
+import java.io.IOException;
+
+final class HyperOsNativeFontPropertySyncer {
+    private HyperOsNativeFontPropertySyncer() {
+    }
+
+    static void publishForceFontTargetAsync(String packageName, int fontScalePercent) {
+        if (packageName == null || packageName.isBlank() || fontScalePercent <= 0) {
+            return;
+        }
+        String fontProperty = HyperOsFlutterFontBridge.forcePropertyNameForPackage(packageName);
+        Thread publisherThread = new Thread(() -> publishPropertyWithRoot(fontProperty, fontScalePercent),
+                "DPIS-hyperos-property-publisher");
+        publisherThread.setDaemon(true);
+        publisherThread.start();
+    }
+
+    static void clearFontTargetAsync(String packageName) {
+        if (packageName == null || packageName.isBlank()) {
+            return;
+        }
+        HyperOsFlutterFontBridge.clearTarget(packageName);
+        String fontProperty = HyperOsFlutterFontBridge.propertyNameForPackage(packageName);
+        String forceFontProperty = HyperOsFlutterFontBridge.forcePropertyNameForPackage(packageName);
+        String rustBinaryProperty = HyperOsFlutterFontBridge.rustBinaryPropertyNameForPackage(packageName);
+        Thread cleanerThread = new Thread(() -> clearPropertiesWithRoot(
+                        fontProperty, forceFontProperty, rustBinaryProperty),
+                "DPIS-hyperos-property-cleaner");
+        cleanerThread.setDaemon(true);
+        cleanerThread.start();
+    }
+    static void syncConfiguredFontTargetsAsync(DpiConfigStore store) {
+        if (store == null || !store.isHyperOsFlutterFontHookEnabled()) {
+            return;
+        }
+        for (String packageName : store.getConfiguredPackages()) {
+            Integer fontScalePercent = store.getTargetFontScalePercent(packageName);
+            String fontMode = store.getTargetFontApplyMode(packageName);
+            if (store.isTargetDpisEnabled(packageName)
+                    && fontScalePercent != null
+                    && fontScalePercent > 0
+                    && FontApplyMode.isEnabled(fontMode)) {
+                publishForceFontTargetAsync(packageName, fontScalePercent);
+            }
+        }
+    }
+
+
+    private static void publishPropertyWithRoot(String fontProperty, int fontScalePercent) {
+        runRootCommand(buildPublishCommand(fontProperty, fontScalePercent));
+    }
+
+    private static void clearPropertiesWithRoot(String fontProperty,
+                                                String forceFontProperty,
+                                                String rustBinaryProperty) {
+        String command = "setprop " + shellQuote(fontProperty) + " 0; "
+                + "setprop " + shellQuote(forceFontProperty) + " 0; "
+                + "setprop " + shellQuote(rustBinaryProperty) + " 0";
+        runRootCommand(command);
+    }
+
+    static String buildPublishCommandForTest(String fontProperty, int fontScalePercent) {
+        return buildPublishCommand(fontProperty, fontScalePercent);
+    }
+
+    private static String buildPublishCommand(String fontProperty, int fontScalePercent) {
+        return "setprop " + shellQuote(fontProperty) + " "
+                + shellQuote(String.valueOf(fontScalePercent));
+    }
+
+    private static void runRootCommand(String command) {
+        Process process = null;
+        try {
+            process = Runtime.getRuntime().exec(new String[] { "su", "-c", command });
+            process.waitFor();
+        } catch (IOException ignored) {
+        } catch (InterruptedException ignored) {
+            Thread.currentThread().interrupt();
+        } finally {
+            if (process != null) {
+                process.destroy();
+            }
+        }
+    }
+    static String shellQuoteForTest(String value) {
+        return shellQuote(value);
+    }
+
+    private static String shellQuote(String value) {
+        if (value == null || value.isEmpty()) {
+            return "''";
+        }
+        return "'" + value.replace("'", "'\\''") + "'";
+    }
+}

--- a/app/src/main/java/com/dpis/module/HyperOsNativeFontPropertySyncer.java
+++ b/app/src/main/java/com/dpis/module/HyperOsNativeFontPropertySyncer.java
@@ -1,6 +1,7 @@
 package com.dpis.module;
 
 import java.io.IOException;
+import java.util.LinkedHashSet;
 
 final class HyperOsNativeFontPropertySyncer {
     private HyperOsNativeFontPropertySyncer() {
@@ -31,6 +32,21 @@ final class HyperOsNativeFontPropertySyncer {
         cleanerThread.setDaemon(true);
         cleanerThread.start();
     }
+
+    static void clearConfiguredFontTargetsAsync(DpiConfigStore store) {
+        if (store == null) {
+            return;
+        }
+        LinkedHashSet<String> packages = new LinkedHashSet<>(store.getConfiguredPackages());
+        if (packages.isEmpty()) {
+            return;
+        }
+        Thread cleanerThread = new Thread(() -> clearFontTargets(packages),
+                "DPIS-hyperos-configured-property-cleaner");
+        cleanerThread.setDaemon(true);
+        cleanerThread.start();
+    }
+
     static void syncConfiguredFontTargetsAsync(DpiConfigStore store) {
         if (store == null || !store.isHyperOsFlutterFontHookEnabled()) {
             return;
@@ -59,6 +75,32 @@ final class HyperOsNativeFontPropertySyncer {
                 + "setprop " + shellQuote(forceFontProperty) + " 0; "
                 + "setprop " + shellQuote(rustBinaryProperty) + " 0";
         runRootCommand(command);
+    }
+
+    private static void clearFontTargets(LinkedHashSet<String> packages) {
+        StringBuilder command = new StringBuilder();
+        for (String packageName : packages) {
+            if (packageName == null || packageName.isBlank()) {
+                continue;
+            }
+            HyperOsFlutterFontBridge.clearTarget(packageName);
+            appendClearCommand(command,
+                    HyperOsFlutterFontBridge.propertyNameForPackage(packageName));
+            appendClearCommand(command,
+                    HyperOsFlutterFontBridge.forcePropertyNameForPackage(packageName));
+            appendClearCommand(command,
+                    HyperOsFlutterFontBridge.rustBinaryPropertyNameForPackage(packageName));
+        }
+        if (command.length() > 0) {
+            runRootCommand(command.toString());
+        }
+    }
+
+    private static void appendClearCommand(StringBuilder command, String property) {
+        if (command.length() > 0) {
+            command.append("; ");
+        }
+        command.append("setprop ").append(shellQuote(property)).append(" 0");
     }
 
     static String buildPublishCommandForTest(String fontProperty, int fontScalePercent) {

--- a/app/src/main/java/com/dpis/module/HyperOsNativeProxyAssetExporter.java
+++ b/app/src/main/java/com/dpis/module/HyperOsNativeProxyAssetExporter.java
@@ -1,0 +1,93 @@
+package com.dpis.module;
+
+import android.content.Context;
+import android.os.Build;
+
+import java.io.File;
+import java.io.FileOutputStream;
+import java.io.IOException;
+import java.io.InputStream;
+import java.util.LinkedHashSet;
+import java.util.Set;
+
+final class HyperOsNativeProxyAssetExporter {
+    private static final String NATIVE_ASSET_ROOT = "native";
+    private static final String NATIVE_PROXY_LIBRARY_NAME = "libdpis_native.so";
+
+    private HyperOsNativeProxyAssetExporter() {
+    }
+
+    static void exportBundledNativeProxyLibrary(Context context) {
+        if (context == null) {
+            return;
+        }
+        String assetPath = resolveNativeProxyAssetPath(
+                listNativeProxyAssetPaths(context), Build.SUPPORTED_ABIS);
+        if (assetPath == null) {
+            DpisLog.e("DPIS_FONT HyperOS proxy library export failed: no matching native asset", null);
+            return;
+        }
+        File output = new File(context.getFilesDir(), NATIVE_PROXY_LIBRARY_NAME);
+        try (InputStream input = context.getAssets().open(assetPath)) {
+            File temp = new File(context.getFilesDir(), NATIVE_PROXY_LIBRARY_NAME + ".tmp");
+            try (FileOutputStream stream = new FileOutputStream(temp)) {
+                byte[] buffer = new byte[16 * 1024];
+                int read;
+                while ((read = input.read(buffer)) != -1) {
+                    stream.write(buffer, 0, read);
+                }
+            }
+            if (!temp.renameTo(output)) {
+                throw new IOException("rename failed: " + temp + " -> " + output);
+            }
+            output.setReadable(true, false);
+            output.setExecutable(true, false);
+        } catch (IOException throwable) {
+            DpisLog.e("DPIS_FONT HyperOS proxy library export failed", throwable);
+        }
+    }
+
+    private static Set<String> listNativeProxyAssetPaths(Context context) {
+        LinkedHashSet<String> paths = new LinkedHashSet<>();
+        try {
+            String[] abis = context.getAssets().list(NATIVE_ASSET_ROOT);
+            if (abis == null) {
+                return paths;
+            }
+            for (String abi : abis) {
+                if (abi == null || abi.isBlank()) {
+                    continue;
+                }
+                String assetPath = NATIVE_ASSET_ROOT + "/" + abi + "/" + NATIVE_PROXY_LIBRARY_NAME;
+                try (InputStream ignored = context.getAssets().open(assetPath)) {
+                    paths.add(assetPath);
+                } catch (IOException ignored) {
+                }
+            }
+        } catch (IOException ignored) {
+        }
+        return paths;
+    }
+
+    static String resolveNativeProxyAssetPath(Set<String> availableAssetPaths, String[] supportedAbis) {
+        if (availableAssetPaths == null || availableAssetPaths.isEmpty()) {
+            return null;
+        }
+        if (supportedAbis != null) {
+            for (String abi : supportedAbis) {
+                if (abi == null || abi.isBlank()) {
+                    continue;
+                }
+                String assetPath = NATIVE_ASSET_ROOT + "/" + abi + "/" + NATIVE_PROXY_LIBRARY_NAME;
+                if (availableAssetPaths.contains(assetPath)) {
+                    return assetPath;
+                }
+            }
+        }
+        String arm64Path = NATIVE_ASSET_ROOT + "/arm64-v8a/" + NATIVE_PROXY_LIBRARY_NAME;
+        if (availableAssetPaths.contains(arm64Path)) {
+            return arm64Path;
+        }
+        return availableAssetPaths.iterator().next();
+    }
+}

--- a/app/src/main/java/com/dpis/module/HyperOsNativeProxyBindMounter.java
+++ b/app/src/main/java/com/dpis/module/HyperOsNativeProxyBindMounter.java
@@ -1,0 +1,143 @@
+package com.dpis.module;
+
+import android.content.Context;
+import android.content.pm.ApplicationInfo;
+import android.content.pm.PackageManager;
+
+import java.io.BufferedReader;
+import java.io.File;
+import java.io.IOException;
+import java.io.InputStreamReader;
+
+final class HyperOsNativeProxyBindMounter {
+    private static final String NATIVE_PROXY_LIBRARY_NAME = "libdpis_native.so";
+
+    private HyperOsNativeProxyBindMounter() {
+    }
+
+    static MountPlan createPlan(Context context, String targetPackageName) {
+        if (context == null || targetPackageName == null || targetPackageName.isBlank()) {
+            return MountPlan.invalid("invalid context or target package");
+        }
+        try {
+            ApplicationInfo moduleInfo = context.getApplicationInfo();
+            ApplicationInfo targetInfo = context.getPackageManager()
+                    .getApplicationInfo(targetPackageName, 0);
+            return createPlan(moduleInfo.nativeLibraryDir, targetInfo.nativeLibraryDir);
+        } catch (PackageManager.NameNotFoundException | RuntimeException exception) {
+            return MountPlan.invalid("target package not found: " + targetPackageName);
+        }
+    }
+
+    static MountPlan createPlan(String moduleNativeLibraryDir, String targetNativeLibraryDir) {
+        if (moduleNativeLibraryDir == null || moduleNativeLibraryDir.isBlank()
+                || targetNativeLibraryDir == null || targetNativeLibraryDir.isBlank()) {
+            return MountPlan.invalid("native library directory missing");
+        }
+        File source = new File(moduleNativeLibraryDir, NATIVE_PROXY_LIBRARY_NAME);
+        File target = new File(targetNativeLibraryDir, NATIVE_PROXY_LIBRARY_NAME);
+        if (!source.isFile()) {
+            return MountPlan.invalid("module proxy library missing: " + source.getAbsolutePath());
+        }
+        if (!target.isFile()) {
+            return MountPlan.invalid("target proxy mount point missing: " + target.getAbsolutePath());
+        }
+        return new MountPlan(source.getAbsolutePath(), target.getAbsolutePath(), true, "");
+    }
+
+    static MountResult apply(MountPlan plan) {
+        if (plan == null || !plan.valid) {
+            return new MountResult(false, plan == null ? "invalid mount plan" : plan.reason);
+        }
+        return runRootCommand(buildApplyCommand(plan.sourcePath, plan.targetPath));
+    }
+
+    static MountResult unmount(MountPlan plan) {
+        if (plan == null || plan.targetPath == null || plan.targetPath.isBlank()) {
+            return new MountResult(false, "invalid mount target");
+        }
+        return runRootCommand(buildUnmountCommand(plan.targetPath));
+    }
+
+    static String buildApplyCommand(String sourcePath, String targetPath) {
+        String source = shellQuote(sourcePath);
+        String target = shellQuote(targetPath);
+        return "(umount -l " + target + " 2>/dev/null || true)"
+                + " && mount -o bind " + source + " " + target
+                + " && mount | grep -F -- " + shellQuote(targetPath) + " >/dev/null"
+                + " && md5sum " + source + " " + target;
+    }
+
+    static String buildUnmountCommand(String targetPath) {
+        String target = shellQuote(targetPath);
+        return "(umount -l " + target + " 2>/dev/null || true)"
+                + " && (mount | grep -F -- " + shellQuote(targetPath)
+                + " >/dev/null && exit 1 || exit 0)";
+    }
+
+    private static MountResult runRootCommand(String command) {
+        Process process = null;
+        StringBuilder output = new StringBuilder();
+        try {
+            process = new ProcessBuilder("su", "-c", command)
+                    .redirectErrorStream(true)
+                    .start();
+            try (BufferedReader reader = new BufferedReader(
+                    new InputStreamReader(process.getInputStream()))) {
+                String line;
+                while ((line = reader.readLine()) != null) {
+                    if (output.length() > 0) {
+                        output.append('\n');
+                    }
+                    output.append(line);
+                }
+            }
+            int exitCode = process.waitFor();
+            return new MountResult(exitCode == 0, output.toString());
+        } catch (IOException exception) {
+            return new MountResult(false, exception.getMessage());
+        } catch (InterruptedException exception) {
+            Thread.currentThread().interrupt();
+            return new MountResult(false, exception.getMessage());
+        } finally {
+            if (process != null) {
+                process.destroy();
+            }
+        }
+    }
+
+    private static String shellQuote(String value) {
+        if (value == null) {
+            return "''";
+        }
+        return "'" + value.replace("'", "'\''") + "'";
+    }
+
+    static final class MountPlan {
+        final String sourcePath;
+        final String targetPath;
+        final boolean valid;
+        final String reason;
+
+        private MountPlan(String sourcePath, String targetPath, boolean valid, String reason) {
+            this.sourcePath = sourcePath;
+            this.targetPath = targetPath;
+            this.valid = valid;
+            this.reason = reason;
+        }
+
+        static MountPlan invalid(String reason) {
+            return new MountPlan(null, null, false, reason == null ? "invalid" : reason);
+        }
+    }
+
+    static final class MountResult {
+        final boolean success;
+        final String output;
+
+        MountResult(boolean success, String output) {
+            this.success = success;
+            this.output = output == null ? "" : output;
+        }
+    }
+}

--- a/app/src/main/java/com/dpis/module/HyperOsNativeProxyBindMounter.java
+++ b/app/src/main/java/com/dpis/module/HyperOsNativeProxyBindMounter.java
@@ -68,17 +68,15 @@ final class HyperOsNativeProxyBindMounter {
         String source = shellQuote(sourcePath);
         String target = shellQuote(targetPath);
         return "umount -l " + target + " 2>/dev/null || true; "
-                + "test ! -s " + target
-                + " || cmp -s " + source + " " + target
-                + " || exit 1; "
                 + "cp -f " + source + " " + target
                 + " || cat " + source + " > " + target
                 + " || exit 1; "
                 + "chown system:system " + target + " 2>/dev/null || true; "
                 + "chmod 755 " + target + " 2>/dev/null || true; "
                 + "chcon u:object_r:apk_data_file:s0 " + target + " 2>/dev/null || true; "
+                + "cmp -s " + source + " " + target + " || exit 1; "
                 + "md5sum " + source + " " + target
-                + " || exit 1";
+                + " 2>/dev/null || true";
     }
 
     static String buildUnmountCommand(String sourcePath, String targetPath) {

--- a/app/src/main/java/com/dpis/module/HyperOsNativeProxyBindMounter.java
+++ b/app/src/main/java/com/dpis/module/HyperOsNativeProxyBindMounter.java
@@ -39,8 +39,12 @@ final class HyperOsNativeProxyBindMounter {
         if (!source.isFile()) {
             return MountPlan.invalid("module proxy library missing: " + source.getAbsolutePath());
         }
-        if (!target.isFile()) {
-            return MountPlan.invalid("target proxy mount point missing: " + target.getAbsolutePath());
+        File targetParent = target.getParentFile();
+        if (targetParent == null || !targetParent.isDirectory()) {
+            return MountPlan.invalid("target native library directory missing: " + targetNativeLibraryDir);
+        }
+        if (target.exists() && !target.isFile()) {
+            return MountPlan.invalid("target proxy mount point is not a file: " + target.getAbsolutePath());
         }
         return new MountPlan(source.getAbsolutePath(), target.getAbsolutePath(), true, "");
     }
@@ -53,26 +57,39 @@ final class HyperOsNativeProxyBindMounter {
     }
 
     static MountResult unmount(MountPlan plan) {
-        if (plan == null || plan.targetPath == null || plan.targetPath.isBlank()) {
+        if (plan == null || plan.sourcePath == null || plan.sourcePath.isBlank()
+                || plan.targetPath == null || plan.targetPath.isBlank()) {
             return new MountResult(false, "invalid mount target");
         }
-        return runRootCommand(buildUnmountCommand(plan.targetPath));
+        return runRootCommand(buildUnmountCommand(plan.sourcePath, plan.targetPath));
     }
 
     static String buildApplyCommand(String sourcePath, String targetPath) {
         String source = shellQuote(sourcePath);
         String target = shellQuote(targetPath);
-        return "(umount -l " + target + " 2>/dev/null || true)"
-                + " && mount -o bind " + source + " " + target
-                + " && mount | grep -F -- " + shellQuote(targetPath) + " >/dev/null"
-                + " && md5sum " + source + " " + target;
+        return "umount -l " + target + " 2>/dev/null || true; "
+                + "test ! -s " + target
+                + " || cmp -s " + source + " " + target
+                + " || exit 1; "
+                + "cp -f " + source + " " + target
+                + " || cat " + source + " > " + target
+                + " || exit 1; "
+                + "chown system:system " + target + " 2>/dev/null || true; "
+                + "chmod 755 " + target + " 2>/dev/null || true; "
+                + "chcon u:object_r:apk_data_file:s0 " + target + " 2>/dev/null || true; "
+                + "md5sum " + source + " " + target
+                + " || exit 1";
     }
 
-    static String buildUnmountCommand(String targetPath) {
+    static String buildUnmountCommand(String sourcePath, String targetPath) {
+        String source = shellQuote(sourcePath);
         String target = shellQuote(targetPath);
-        return "(umount -l " + target + " 2>/dev/null || true)"
-                + " && (mount | grep -F -- " + shellQuote(targetPath)
-                + " >/dev/null && exit 1 || exit 0)";
+        return "umount -l " + target + " 2>/dev/null || true; "
+                + "test ! -e " + target
+                + " || cmp -s " + source + " " + target
+                + " || exit 1; "
+                + "rm -f " + target + " 2>/dev/null || true; "
+                + "test ! -e " + target + " || test ! -s " + target;
     }
 
     private static MountResult runRootCommand(String command) {

--- a/app/src/main/java/com/dpis/module/HyperOsNativeProxyRefreshCoordinator.java
+++ b/app/src/main/java/com/dpis/module/HyperOsNativeProxyRefreshCoordinator.java
@@ -1,0 +1,69 @@
+package com.dpis.module;
+
+import android.content.Context;
+
+import java.util.LinkedHashSet;
+
+final class HyperOsNativeProxyRefreshCoordinator {
+    private HyperOsNativeProxyRefreshCoordinator() {
+    }
+
+    /*
+     * Dormant helper: automatic startup/package-update proxy refresh is intentionally disabled.
+     * Keep this entry point for a future explicit user action or opt-in flow only; do not wire it
+     * back into app startup, service binding, or MY_PACKAGE_REPLACED without revisiting the native
+     * file side-effect scope.
+     */
+    static void refreshConfiguredTargetsAsync(Context context, DpiConfigStore store) {
+        if (context == null || store == null) {
+            return;
+        }
+        LinkedHashSet<String> packages = collectRefreshPackages(store);
+        if (packages.isEmpty()) {
+            return;
+        }
+        Thread refreshThread = new Thread(() -> refreshConfiguredTargets(context, packages),
+                "DPIS-HyperOsNativeProxyRefresh");
+        refreshThread.setDaemon(true);
+        refreshThread.start();
+    }
+
+    static LinkedHashSet<String> collectRefreshPackagesForTest(DpiConfigStore store) {
+        return collectRefreshPackages(store);
+    }
+
+    private static LinkedHashSet<String> collectRefreshPackages(DpiConfigStore store) {
+        LinkedHashSet<String> packages = new LinkedHashSet<>();
+        if (store == null || !store.isHyperOsFlutterFontHookEnabled()) {
+            return packages;
+        }
+        for (String packageName : store.getConfiguredPackages()) {
+            Integer fontScalePercent = store.getTargetFontScalePercent(packageName);
+            String fontMode = store.getTargetFontApplyMode(packageName);
+            if (store.isTargetDpisEnabled(packageName)
+                    && fontScalePercent != null
+                    && fontScalePercent > 0
+                    && FontApplyMode.isEnabled(fontMode)) {
+                packages.add(packageName);
+            }
+        }
+        return packages;
+    }
+
+    private static void refreshConfiguredTargets(Context context, LinkedHashSet<String> packages) {
+        for (String packageName : packages) {
+            HyperOsNativeProxyBindMounter.MountPlan plan =
+                    HyperOsNativeProxyBindMounter.createPlan(context, packageName);
+            if (!plan.valid) {
+                DpisLog.i("HyperOS Native Proxy refresh skipped package=" + packageName
+                        + " reason=" + plan.reason);
+                continue;
+            }
+            HyperOsNativeProxyBindMounter.MountResult result =
+                    HyperOsNativeProxyBindMounter.apply(plan);
+            DpisLog.i("HyperOS Native Proxy refresh package=" + packageName
+                    + " success=" + result.success
+                    + " output=" + result.output);
+        }
+    }
+}

--- a/app/src/main/java/com/dpis/module/HyperOsNativeProxyStatus.java
+++ b/app/src/main/java/com/dpis/module/HyperOsNativeProxyStatus.java
@@ -1,0 +1,57 @@
+package com.dpis.module;
+
+import android.content.Context;
+import android.content.pm.ApplicationInfo;
+import android.content.pm.PackageManager;
+
+import java.io.File;
+
+final class HyperOsNativeProxyStatus {
+    private static final String NATIVE_PROXY_LIBRARY_NAME = "libdpis_native.so";
+
+    enum State {
+        PRESENT,
+        MISSING,
+        UNKNOWN
+    }
+
+    final State state;
+    final String nativeLibraryDir;
+
+    private HyperOsNativeProxyStatus(State state, String nativeLibraryDir) {
+        this.state = state;
+        this.nativeLibraryDir = nativeLibraryDir;
+    }
+
+    static HyperOsNativeProxyStatus inspect(Context context, String packageName) {
+        if (context == null || packageName == null || packageName.isBlank()) {
+            return new HyperOsNativeProxyStatus(State.UNKNOWN, null);
+        }
+        try {
+            ApplicationInfo applicationInfo = context.getPackageManager()
+                    .getApplicationInfo(packageName, 0);
+            return inspectNativeLibraryDir(applicationInfo.nativeLibraryDir);
+        } catch (PackageManager.NameNotFoundException | RuntimeException ignored) {
+            return new HyperOsNativeProxyStatus(State.UNKNOWN, null);
+        }
+    }
+
+    static HyperOsNativeProxyStatus inspectNativeLibraryDir(String nativeLibraryDir) {
+        if (nativeLibraryDir == null || nativeLibraryDir.isBlank()) {
+            return new HyperOsNativeProxyStatus(State.UNKNOWN, nativeLibraryDir);
+        }
+        File nativeDir = new File(nativeLibraryDir);
+        File proxy = new File(nativeDir, NATIVE_PROXY_LIBRARY_NAME);
+        if (proxy.isFile()) {
+            return new HyperOsNativeProxyStatus(State.PRESENT, nativeLibraryDir);
+        }
+        if (nativeDir.isDirectory()) {
+            return new HyperOsNativeProxyStatus(State.MISSING, nativeLibraryDir);
+        }
+        return new HyperOsNativeProxyStatus(State.UNKNOWN, nativeLibraryDir);
+    }
+
+    boolean isPresent() {
+        return state == State.PRESENT;
+    }
+}

--- a/app/src/main/java/com/dpis/module/HyperOsNativeProxyStatus.java
+++ b/app/src/main/java/com/dpis/module/HyperOsNativeProxyStatus.java
@@ -42,7 +42,7 @@ final class HyperOsNativeProxyStatus {
         }
         File nativeDir = new File(nativeLibraryDir);
         File proxy = new File(nativeDir, NATIVE_PROXY_LIBRARY_NAME);
-        if (proxy.isFile()) {
+        if (proxy.isFile() && proxy.length() > 0) {
             return new HyperOsNativeProxyStatus(State.PRESENT, nativeLibraryDir);
         }
         if (nativeDir.isDirectory()) {

--- a/app/src/main/java/com/dpis/module/HyperOsRustProcessHookInstaller.java
+++ b/app/src/main/java/com/dpis/module/HyperOsRustProcessHookInstaller.java
@@ -1,0 +1,165 @@
+package com.dpis.module;
+
+import java.lang.reflect.Method;
+import java.lang.reflect.Modifier;
+import java.io.File;
+import java.util.List;
+import java.util.Locale;
+
+import io.github.libxposed.api.XposedInterface;
+
+final class HyperOsRustProcessHookInstaller {
+    private static final String RUST_PROCESS_IMPL = "android.os.RustProcessImpl";
+    private static final String START_RUST_PROCESS = "startRustProcess";
+    private static final int ARG_PACKAGE_NAME = 1;
+    private static final int ARG_ENVIRONMENTS = 21;
+    private static final int ARG_BINARY_PATH = 20;
+    private static final String MODULE_PACKAGE = "io.github.kwensiu.dpis";
+    private static final String NATIVE_LIBRARY_NAME = "libdpis_native.so";
+
+    private HyperOsRustProcessHookInstaller() {
+    }
+
+    static boolean install(XposedInterface xposed, PerAppDisplayConfigSource source) {
+        Class<?> clazz = resolveClass(RUST_PROCESS_IMPL);
+        if (clazz == null) {
+            DpisLog.i("DPIS_FONT HyperOS Rust process hook missing: class=" + RUST_PROCESS_IMPL);
+            return false;
+        }
+        boolean hooked = false;
+        for (Method method : clazz.getDeclaredMethods()) {
+            if (!START_RUST_PROCESS.equals(method.getName())
+                    || Modifier.isAbstract(method.getModifiers())) {
+                continue;
+            }
+            xposed.hook(method)
+                    .setExceptionMode(XposedInterface.ExceptionMode.PROTECTIVE)
+                    .intercept(chain -> {
+                        try {
+                            List<Object> args = chain.getArgs();
+                            Object[] updatedArgs = applyEnvironmentArgs(source, args);
+                            if (updatedArgs != null) {
+                                return chain.proceed(updatedArgs);
+                            }
+                        } catch (Throwable throwable) {
+                            DpisLog.e("DPIS_FONT HyperOS Rust process env hook failed", throwable);
+                        }
+                        return chain.proceed();
+                    });
+            hooked = true;
+        }
+        if (hooked) {
+            DpisLog.i("DPIS_FONT HyperOS Rust process hook ready: class=" + RUST_PROCESS_IMPL
+                    + ", method=" + START_RUST_PROCESS);
+        } else {
+            DpisLog.i("DPIS_FONT HyperOS Rust process hook missing: method=" + START_RUST_PROCESS);
+        }
+        return hooked;
+    }
+
+    static String appendEnvironmentForTest(String existing,
+                                           String packageName,
+                                           int targetFontScalePercent,
+                                           String binaryPath) {
+        return appendEnvironment(existing, packageName, targetFontScalePercent, binaryPath);
+    }
+
+    private static Object[] applyEnvironmentArgs(PerAppDisplayConfigSource source, List<Object> args) {
+        if (source == null || args == null || args.size() <= ARG_ENVIRONMENTS) {
+            return null;
+        }
+        Object packageValue = args.get(ARG_PACKAGE_NAME);
+        if (!(packageValue instanceof String)) {
+            return null;
+        }
+        String packageName = (String) packageValue;
+        PerAppDisplayConfig config = source.get(packageName);
+        if (config == null
+                || config.targetFontScalePercent == null
+                || config.targetFontScalePercent <= 0) {
+            HyperOsFlutterFontBridge.clearTarget(packageName);
+            return null;
+        }
+        Object existingValue = args.get(ARG_ENVIRONMENTS);
+        String existing = existingValue instanceof String ? (String) existingValue : "";
+        Object binaryValue = args.size() > ARG_BINARY_PATH ? args.get(ARG_BINARY_PATH) : null;
+        String binaryPath = binaryValue instanceof String ? (String) binaryValue : "";
+        String updated = appendEnvironment(existing, packageName,
+                config.targetFontScalePercent, binaryPath);
+        HyperOsFlutterFontBridge.publishRustBinaryPath(packageName, binaryPath);
+        HyperOsFlutterFontBridge.publishRustProxyTarget(packageName, config);
+        String proxyLibraryPath = resolveProxyLibraryPath(binaryPath);
+        if (proxyLibraryPath == null || proxyLibraryPath.isEmpty()) {
+            DpisLog.i("DPIS_FONT HyperOS Rust process proxy missing: package=" + packageName);
+            return null;
+        }
+        DpisLog.i("DPIS_FONT HyperOS Rust process env apply: package=" + packageName
+                + ", binary=" + binaryPath
+                + ", proxy=" + proxyLibraryPath
+                + ", envs=" + updated);
+        Object[] updatedArgs = args.toArray();
+        updatedArgs[ARG_BINARY_PATH] = proxyLibraryPath;
+        updatedArgs[ARG_ENVIRONMENTS] = updated;
+        return updatedArgs;
+    }
+
+    private static String resolveProxyLibraryPath(String originalBinaryPath) {
+        return resolveSiblingProxyLibraryPath(originalBinaryPath);
+    }
+
+    private static String resolveSiblingProxyLibraryPath(String originalBinaryPath) {
+        if (originalBinaryPath == null || originalBinaryPath.isEmpty()) {
+            return null;
+        }
+        File parent = new File(originalBinaryPath).getParentFile();
+        if (parent == null) {
+            return null;
+        }
+        File proxy = new File(parent, NATIVE_LIBRARY_NAME);
+        return proxy.isFile() ? proxy.getAbsolutePath() : null;
+    }
+
+    private static String appendEnvironment(String existing,
+                                            String packageName,
+                                            int targetFontScalePercent,
+                                            String binaryPath) {
+        StringBuilder builder = new StringBuilder();
+        if (existing != null && !existing.trim().isEmpty()) {
+            builder.append(existing.trim());
+            if (builder.charAt(builder.length() - 1) != ',') {
+                builder.append(',');
+            }
+        }
+        appendPair(builder, "DPIS_PACKAGE", packageName);
+        appendPair(builder, "DPIS_FONT_SCALE_PERCENT",
+                String.format(Locale.US, "%d", targetFontScalePercent));
+        appendPair(builder, "DPIS_RUST_BINARY", binaryPath == null ? "" : binaryPath);
+        builder.append(" --cold-boot-speed");
+        return builder.toString();
+    }
+
+    private static void appendPair(StringBuilder builder, String key, String value) {
+        if (builder.length() > 0) {
+            builder.append(" --envs=");
+        }
+        builder.append(key).append('=').append(sanitize(value));
+    }
+
+    private static String sanitize(String value) {
+        if (value == null) {
+            return "";
+        }
+        return value.replace(',', '_')
+                .replace('\n', '_')
+                .replace('\r', '_')
+                .replace(' ', '_');
+    }
+
+    private static Class<?> resolveClass(String className) {
+        try {
+            return Class.forName(className);
+        } catch (Throwable ignored) {
+            return null;
+        }
+    }
+}

--- a/app/src/main/java/com/dpis/module/HyperOsRustProcessHookInstaller.java
+++ b/app/src/main/java/com/dpis/module/HyperOsRustProcessHookInstaller.java
@@ -16,7 +16,6 @@ final class HyperOsRustProcessHookInstaller {
     private static final int ARG_BINARY_PATH = 20;
     private static final String MODULE_PACKAGE = "io.github.kwensiu.dpis";
     private static final String NATIVE_LIBRARY_NAME = "libdpis_native.so";
-
     private HyperOsRustProcessHookInstaller() {
     }
 
@@ -62,6 +61,10 @@ final class HyperOsRustProcessHookInstaller {
                                            int targetFontScalePercent,
                                            String binaryPath) {
         return appendEnvironment(existing, packageName, targetFontScalePercent, binaryPath);
+    }
+
+    static String resolveProxyLibraryPathForTest(String originalBinaryPath) {
+        return resolveProxyLibraryPath(originalBinaryPath);
     }
 
     private static Object[] applyEnvironmentArgs(PerAppDisplayConfigSource source, List<Object> args) {

--- a/app/src/main/java/com/dpis/module/HyperOsRustProcessHookInstaller.java
+++ b/app/src/main/java/com/dpis/module/HyperOsRustProcessHookInstaller.java
@@ -119,7 +119,7 @@ final class HyperOsRustProcessHookInstaller {
             return null;
         }
         File proxy = new File(parent, NATIVE_LIBRARY_NAME);
-        return proxy.isFile() ? proxy.getAbsolutePath() : null;
+        return proxy.isFile() && proxy.length() > 0 ? proxy.getAbsolutePath() : null;
     }
 
     private static String appendEnvironment(String existing,

--- a/app/src/main/java/com/dpis/module/InstalledAppCatalogCoordinator.java
+++ b/app/src/main/java/com/dpis/module/InstalledAppCatalogCoordinator.java
@@ -95,7 +95,8 @@ final class InstalledAppCatalogCoordinator {
             Drawable icon = resolveDisplayIcon(item);
             result.add(new AppListItem(item.label, item.packageName,
                     scopePackages.contains(item.packageName), viewportWidth, viewportMode,
-                    fontScalePercent, fontMode, dpisEnabled, item.systemApp, icon));
+                    fontScalePercent, fontMode, dpisEnabled, item.systemApp,
+                    item.hyperOsNativeProxyCandidate, icon));
         }
         return result;
     }
@@ -165,9 +166,9 @@ final class InstalledAppCatalogCoordinator {
             List<ApplicationInfo> installedApps;
             if (Build.VERSION.SDK_INT >= Build.VERSION_CODES.TIRAMISU) {
                 installedApps = packageManager.getInstalledApplications(
-                        PackageManager.ApplicationInfoFlags.of(0));
+                        PackageManager.ApplicationInfoFlags.of(PackageManager.GET_META_DATA));
             } else {
-                installedApps = packageManager.getInstalledApplications(0);
+                installedApps = packageManager.getInstalledApplications(PackageManager.GET_META_DATA);
             }
 
             List<InstalledAppCatalogItem> rebuilt = new ArrayList<>();
@@ -181,6 +182,7 @@ final class InstalledAppCatalogCoordinator {
                         label,
                         applicationInfo.packageName,
                         systemApp,
+                        HyperOsNativeAppDetector.isNativeProxyCandidate(applicationInfo),
                         previousIcons.get(applicationInfo.packageName)));
             }
             rebuilt.sort(Comparator.comparing(
@@ -318,16 +320,23 @@ final class InstalledAppCatalogCoordinator {
                 && (flags & ApplicationInfo.FLAG_UPDATED_SYSTEM_APP) == 0;
     }
 
+
     private static final class InstalledAppCatalogItem {
         final String label;
         final String packageName;
         final boolean systemApp;
+        final boolean hyperOsNativeProxyCandidate;
         volatile Drawable icon;
 
-        InstalledAppCatalogItem(String label, String packageName, boolean systemApp, Drawable icon) {
+        InstalledAppCatalogItem(String label,
+                String packageName,
+                boolean systemApp,
+                boolean hyperOsNativeProxyCandidate,
+                Drawable icon) {
             this.label = label;
             this.packageName = packageName;
             this.systemApp = systemApp;
+            this.hyperOsNativeProxyCandidate = hyperOsNativeProxyCandidate;
             this.icon = icon;
         }
     }

--- a/app/src/main/java/com/dpis/module/MainActivity.java
+++ b/app/src/main/java/com/dpis/module/MainActivity.java
@@ -249,6 +249,9 @@ public final class MainActivity extends LocalizedActivity implements DpisApplica
                 .setOnClickListener(v -> startActivity(new Intent(this, SystemServerSettingsActivity.class)));
 
         renderMainUiState(requireUiState());
+        if (maybeShowModuleRuntimeReloadAdvice()) {
+            return;
+        }
         if (!maybeShowStartupDisclaimerDialog()) {
             maybeCheckForUpdatesOnStartup();
         }
@@ -623,6 +626,9 @@ public final class MainActivity extends LocalizedActivity implements DpisApplica
             showToast(R.string.system_settings_save_failed);
             return false;
         }
+        if (!enabled) {
+            HyperOsNativeFontPropertySyncer.clearFontTargetAsync(packageName);
+        }
         showToast(enabled ? R.string.dialog_dpis_enabled_status : R.string.dialog_dpis_disabled_status);
         requestAppsLoad();
         return true;
@@ -730,6 +736,23 @@ public final class MainActivity extends LocalizedActivity implements DpisApplica
         return startupUpdateDialogCoordinator().maybeShowStartupDisclaimerDialog(
                 getUiConfigStore(),
                 this::maybeCheckForUpdatesOnStartup);
+    }
+
+    private boolean maybeShowModuleRuntimeReloadAdvice() {
+        if (!ModuleRuntimeReloadAdvisor.shouldShowReloadAdvice(this)) {
+            return false;
+        }
+        new AlertDialog.Builder(this)
+                .setTitle(R.string.module_runtime_reload_title)
+                .setMessage(R.string.module_runtime_reload_message)
+                .setPositiveButton(R.string.module_runtime_reload_ack_button, (dialog, which) -> {
+                    ModuleRuntimeReloadAdvisor.markReloadAdviceAcknowledged(this);
+                    if (!maybeShowStartupDisclaimerDialog()) {
+                        maybeCheckForUpdatesOnStartup();
+                    }
+                })
+                .show();
+        return true;
     }
 
     private void maybeCheckForUpdatesOnStartup() {

--- a/app/src/main/java/com/dpis/module/MainActivity.java
+++ b/app/src/main/java/com/dpis/module/MainActivity.java
@@ -628,6 +628,7 @@ public final class MainActivity extends LocalizedActivity implements DpisApplica
         }
         if (!enabled) {
             HyperOsNativeFontPropertySyncer.clearFontTargetAsync(packageName);
+            ViewportPropertySyncer.clearTargetAsync(packageName);
         }
         showToast(enabled ? R.string.dialog_dpis_enabled_status : R.string.dialog_dpis_disabled_status);
         requestAppsLoad();
@@ -1084,6 +1085,16 @@ public final class MainActivity extends LocalizedActivity implements DpisApplica
             }
 
             @Override
+            public void applyHyperOsNativeProxy(AppListItem item, Runnable onFinished) {
+                executeHyperOsNativeProxyMount(item, true, onFinished);
+            }
+
+            @Override
+            public void unmountHyperOsNativeProxy(AppListItem item, Runnable onFinished) {
+                executeHyperOsNativeProxyMount(item, false, onFinished);
+            }
+
+            @Override
             public boolean setDpisEnabled(String packageName, boolean enabled) {
                 return MainActivity.this.setDpisEnabled(packageName, enabled);
             }
@@ -1111,6 +1122,32 @@ public final class MainActivity extends LocalizedActivity implements DpisApplica
                 MainActivity.this.showToast(messageResId);
             }
         };
+    }
+
+    private void executeHyperOsNativeProxyMount(
+            AppListItem item, boolean apply, Runnable onFinished) {
+        new Thread(() -> {
+            HyperOsNativeProxyBindMounter.MountPlan plan =
+                    HyperOsNativeProxyBindMounter.createPlan(this, item.packageName);
+            HyperOsNativeProxyBindMounter.MountResult result = apply
+                    ? HyperOsNativeProxyBindMounter.apply(plan)
+                    : HyperOsNativeProxyBindMounter.unmount(plan);
+            DpisLog.i("HyperOS Native Proxy " + (apply ? "apply" : "rollback")
+                    + " package=" + item.packageName
+                    + " success=" + result.success
+                    + " output=" + result.output);
+            int messageResId = apply
+                    ? R.string.dialog_hyperos_native_proxy_apply_failed
+                    : R.string.dialog_hyperos_native_proxy_unmount_failed;
+            runOnUiThread(() -> {
+                if (!result.success) {
+                    showToast(messageResId);
+                }
+                if (onFinished != null) {
+                    onFinished.run();
+                }
+            });
+        }, "DPIS-HyperOsNativeProxyMount").start();
     }
 
     private void executeDialogProcessAction(AppListItem item, AppConfigDialogBinder.ProcessAction action) {

--- a/app/src/main/java/com/dpis/module/MainActivity.java
+++ b/app/src/main/java/com/dpis/module/MainActivity.java
@@ -746,14 +746,28 @@ public final class MainActivity extends LocalizedActivity implements DpisApplica
         new AlertDialog.Builder(this)
                 .setTitle(R.string.module_runtime_reload_title)
                 .setMessage(R.string.module_runtime_reload_message)
-                .setPositiveButton(R.string.module_runtime_reload_ack_button, (dialog, which) -> {
+                .setPositiveButton(R.string.module_runtime_reload_now_button, (dialog, which) -> {
                     ModuleRuntimeReloadAdvisor.markReloadAdviceAcknowledged(this);
-                    if (!maybeShowStartupDisclaimerDialog()) {
-                        maybeCheckForUpdatesOnStartup();
-                    }
+                    showToast(R.string.module_runtime_reload_started);
+                    ModuleRuntimeReloader.softReloadAsync((success, output) -> runOnUiThread(() -> {
+                        if (!success && !isFinishing() && !isDestroyed()) {
+                            showToast(R.string.module_runtime_reload_failed);
+                            continueStartupDialogsAfterRuntimeReloadAdvice();
+                        }
+                    }));
+                })
+                .setNegativeButton(R.string.module_runtime_reload_later_button, (dialog, which) -> {
+                    ModuleRuntimeReloadAdvisor.markReloadAdviceAcknowledged(this);
+                    continueStartupDialogsAfterRuntimeReloadAdvice();
                 })
                 .show();
         return true;
+    }
+
+    private void continueStartupDialogsAfterRuntimeReloadAdvice() {
+        if (!maybeShowStartupDisclaimerDialog()) {
+            maybeCheckForUpdatesOnStartup();
+        }
     }
 
     private void maybeCheckForUpdatesOnStartup() {

--- a/app/src/main/java/com/dpis/module/MainActivity.java
+++ b/app/src/main/java/com/dpis/module/MainActivity.java
@@ -1126,6 +1126,15 @@ public final class MainActivity extends LocalizedActivity implements DpisApplica
 
     private void executeHyperOsNativeProxyMount(
             AppListItem item, boolean apply, Runnable onFinished) {
+        executeHyperOsNativeProxyMount(item, apply, ignored -> {
+            if (onFinished != null) {
+                onFinished.run();
+            }
+        });
+    }
+
+    private void executeHyperOsNativeProxyMount(
+            AppListItem item, boolean apply, HyperOsNativeProxyMountCallback onFinished) {
         new Thread(() -> {
             HyperOsNativeProxyBindMounter.MountPlan plan =
                     HyperOsNativeProxyBindMounter.createPlan(this, item.packageName);
@@ -1144,13 +1153,29 @@ public final class MainActivity extends LocalizedActivity implements DpisApplica
                     showToast(messageResId);
                 }
                 if (onFinished != null) {
-                    onFinished.run();
+                    onFinished.onFinished(result.success);
                 }
             });
         }, "DPIS-HyperOsNativeProxyMount").start();
     }
 
     private void executeDialogProcessAction(AppListItem item, AppConfigDialogBinder.ProcessAction action) {
+        if (action == AppConfigDialogBinder.ProcessAction.RESTART
+                && item.hyperOsNativeProxyCandidate
+                && item.fontScalePercent != null
+                && item.fontScalePercent > 0) {
+            executeHyperOsNativeProxyMount(item, true, success -> {
+                if (success) {
+                    executeDialogProcessActionAfterHyperOsProxyReady(item, action);
+                }
+            });
+            return;
+        }
+        executeDialogProcessActionAfterHyperOsProxyReady(item, action);
+    }
+
+    private void executeDialogProcessActionAfterHyperOsProxyReady(
+            AppListItem item, AppConfigDialogBinder.ProcessAction action) {
         ProcessActionHandler.Action mappedAction = switch (action) {
             case START -> ProcessActionHandler.Action.START;
             case RESTART -> ProcessActionHandler.Action.RESTART;
@@ -1161,6 +1186,10 @@ public final class MainActivity extends LocalizedActivity implements DpisApplica
 
     private boolean isSystemHookEnabledFromStore() {
         return cachedSystemHookEffectiveEnabled;
+    }
+
+    private interface HyperOsNativeProxyMountCallback {
+        void onFinished(boolean success);
     }
 
     private void refreshSystemHookEffectiveEnabled() {

--- a/app/src/main/java/com/dpis/module/ModuleMain.java
+++ b/app/src/main/java/com/dpis/module/ModuleMain.java
@@ -20,6 +20,9 @@ public final class ModuleMain extends XposedModule {
         DpisLog.setLoggingEnabled(configStore.isGlobalLogEnabled());
         String message = "module loaded: process=" + param.getProcessName()
                 + ", marker=" + SystemServerDisplayDiagnostics.BUILD_MARKER;
+        if (SystemServerProcess.isSystemServer(param.getProcessName(), "")) {
+            ModuleRuntimeStateReporter.reportSystemServerLoaded();
+        }
         SystemServerDisplayDiagnostics.recordPending(
                 message);
         DpisLog.i(message);
@@ -63,6 +66,7 @@ public final class ModuleMain extends XposedModule {
                 + ", targetViewportMode=" + targetViewportMode
                 + ", targetFontScalePercent=" + targetFontScalePercent
                 + ", targetFontMode=" + targetFontMode);
+        HyperOsFlutterFontHookInstaller.install(packageName, store);
         try {
             AppProcessHookInstaller.install(this, packageName, store, policy,
                     targetViewportWidthDp != null, targetViewportMode, targetFontMode,

--- a/app/src/main/java/com/dpis/module/ModuleMain.java
+++ b/app/src/main/java/com/dpis/module/ModuleMain.java
@@ -16,6 +16,7 @@ public final class ModuleMain extends XposedModule {
         moduleLoadedObserved = true;
         currentProcessName = param.getProcessName();
         configStore = ConfigStoreFactory.createForXposedHost(this);
+        FontDebugStatsTransport.initialize(this);
         DpisLog.setLoggingEnabled(configStore.isGlobalLogEnabled());
         String message = "module loaded: process=" + param.getProcessName()
                 + ", marker=" + SystemServerDisplayDiagnostics.BUILD_MARKER;
@@ -75,6 +76,7 @@ public final class ModuleMain extends XposedModule {
         DpiConfigStore local = configStore;
         if (local == null) {
             local = ConfigStoreFactory.createForXposedHost(this);
+            FontDebugStatsTransport.initialize(this);
             configStore = local;
         }
         return local;

--- a/app/src/main/java/com/dpis/module/ModuleRuntimeReloadAdvisor.java
+++ b/app/src/main/java/com/dpis/module/ModuleRuntimeReloadAdvisor.java
@@ -1,0 +1,60 @@
+package com.dpis.module;
+
+import android.content.Context;
+import android.content.SharedPreferences;
+import android.content.pm.PackageInfo;
+import android.content.pm.PackageManager;
+
+final class ModuleRuntimeReloadAdvisor {
+    private static final String PREFS_NAME = "dpis.module_runtime";
+    private static final String KEY_ACKED_UPDATE_TIME = "acked_update_time";
+    private static final long RUNTIME_LOAD_TOLERANCE_MS = 2_000L;
+
+    private ModuleRuntimeReloadAdvisor() {
+    }
+
+    static boolean shouldShowReloadAdvice(Context context) {
+        long lastUpdateTime = getLastUpdateTime(context);
+        long systemServerLoadedAt = ModuleRuntimeStateReporter.getSystemServerLoadedAt();
+        if (!isSystemServerRuntimeOlderThanInstall(lastUpdateTime, systemServerLoadedAt)) {
+            return false;
+        }
+        SharedPreferences preferences = getPreferences(context);
+        return preferences.getLong(KEY_ACKED_UPDATE_TIME, 0L) != lastUpdateTime;
+    }
+
+    static void markReloadAdviceAcknowledged(Context context) {
+        long lastUpdateTime = getLastUpdateTime(context);
+        if (lastUpdateTime <= 0L) {
+            return;
+        }
+        getPreferences(context).edit()
+                .putLong(KEY_ACKED_UPDATE_TIME, lastUpdateTime)
+                .apply();
+    }
+
+    static boolean isSystemServerRuntimeOlderThanInstall(long lastUpdateTime,
+                                                         long systemServerLoadedAt) {
+        if (lastUpdateTime <= 0L || systemServerLoadedAt <= 0L) {
+            return false;
+        }
+        return lastUpdateTime > systemServerLoadedAt + RUNTIME_LOAD_TOLERANCE_MS;
+    }
+
+    private static long getLastUpdateTime(Context context) {
+        if (context == null) {
+            return 0L;
+        }
+        try {
+            PackageInfo packageInfo = context.getPackageManager()
+                    .getPackageInfo(context.getPackageName(), 0);
+            return packageInfo.lastUpdateTime;
+        } catch (PackageManager.NameNotFoundException | RuntimeException ignored) {
+            return 0L;
+        }
+    }
+
+    private static SharedPreferences getPreferences(Context context) {
+        return context.getSharedPreferences(PREFS_NAME, Context.MODE_PRIVATE);
+    }
+}

--- a/app/src/main/java/com/dpis/module/ModuleRuntimeReloader.java
+++ b/app/src/main/java/com/dpis/module/ModuleRuntimeReloader.java
@@ -1,0 +1,73 @@
+package com.dpis.module;
+
+import java.io.BufferedReader;
+import java.io.IOException;
+import java.io.InputStreamReader;
+
+final class ModuleRuntimeReloader {
+    interface Callback {
+        void onFinished(boolean success, String output);
+    }
+
+    private ModuleRuntimeReloader() {
+    }
+
+    static void softReloadAsync(Callback callback) {
+        Thread reloadThread = new Thread(() -> {
+            ShellResult result = runRootCommand(buildSoftReloadCommand());
+            if (callback != null) {
+                callback.onFinished(result.success, result.output);
+            }
+        }, "DPIS-ModuleRuntimeReload");
+        reloadThread.setDaemon(true);
+        reloadThread.start();
+    }
+
+    static String buildSoftReloadCommandForTest() {
+        return buildSoftReloadCommand();
+    }
+
+    private static String buildSoftReloadCommand() {
+        return "setprop ctl.restart zygote; setprop ctl.restart zygote_secondary";
+    }
+
+    private static ShellResult runRootCommand(String command) {
+        Process process = null;
+        StringBuilder output = new StringBuilder();
+        try {
+            process = new ProcessBuilder("su", "-c", command)
+                    .redirectErrorStream(true)
+                    .start();
+            try (BufferedReader reader = new BufferedReader(
+                    new InputStreamReader(process.getInputStream()))) {
+                String line;
+                while ((line = reader.readLine()) != null) {
+                    if (output.length() > 0) {
+                        output.append('\n');
+                    }
+                    output.append(line);
+                }
+            }
+            return new ShellResult(process.waitFor() == 0, output.toString());
+        } catch (IOException exception) {
+            return new ShellResult(false, exception.getMessage());
+        } catch (InterruptedException exception) {
+            Thread.currentThread().interrupt();
+            return new ShellResult(false, exception.getMessage());
+        } finally {
+            if (process != null) {
+                process.destroy();
+            }
+        }
+    }
+
+    private static final class ShellResult {
+        final boolean success;
+        final String output;
+
+        ShellResult(boolean success, String output) {
+            this.success = success;
+            this.output = output == null ? "" : output;
+        }
+    }
+}

--- a/app/src/main/java/com/dpis/module/ModuleRuntimeStateReporter.java
+++ b/app/src/main/java/com/dpis/module/ModuleRuntimeStateReporter.java
@@ -1,0 +1,45 @@
+package com.dpis.module;
+
+import java.lang.reflect.Method;
+
+final class ModuleRuntimeStateReporter {
+    private static final String KEY_SYSTEM_SERVER_LOADED_AT = "debug.dpis.module.system_server_loaded_at";
+
+    private ModuleRuntimeStateReporter() {
+    }
+
+    static void reportSystemServerLoaded() {
+        setSystemProperty(KEY_SYSTEM_SERVER_LOADED_AT,
+                String.valueOf(System.currentTimeMillis()));
+    }
+
+    static long getSystemServerLoadedAt() {
+        String value = getSystemProperty(KEY_SYSTEM_SERVER_LOADED_AT, "0");
+        try {
+            return Long.parseLong(value);
+        } catch (NumberFormatException ignored) {
+            return 0L;
+        }
+    }
+
+    private static void setSystemProperty(String key, String value) {
+        try {
+            Class<?> systemProperties = Class.forName("android.os.SystemProperties");
+            Method set = systemProperties.getDeclaredMethod("set", String.class, String.class);
+            set.invoke(null, key, value);
+        } catch (Throwable throwable) {
+            DpisLog.e("module runtime state report failed: key=" + key, throwable);
+        }
+    }
+
+    private static String getSystemProperty(String key, String fallback) {
+        try {
+            Class<?> systemProperties = Class.forName("android.os.SystemProperties");
+            Method get = systemProperties.getDeclaredMethod("get", String.class, String.class);
+            Object value = get.invoke(null, key, fallback);
+            return value instanceof String ? (String) value : fallback;
+        } catch (Throwable ignored) {
+            return fallback;
+        }
+    }
+}

--- a/app/src/main/java/com/dpis/module/PerAppDisplayConfig.java
+++ b/app/src/main/java/com/dpis/module/PerAppDisplayConfig.java
@@ -5,6 +5,7 @@ final class PerAppDisplayConfig {
     final int targetViewportWidthDp;
     final Integer targetFontScalePercent;
     final String targetFontMode;
+    final boolean hyperOsFlutterFontHookEnabled;
     final boolean viewportOverrideEnabled;
 
     PerAppDisplayConfig(String packageName, int targetViewportWidthDp) {
@@ -24,12 +25,21 @@ final class PerAppDisplayConfig {
 
     PerAppDisplayConfig(String packageName, Integer targetViewportWidthDp,
                         Integer targetFontScalePercent, String targetFontMode) {
+        this(packageName, targetViewportWidthDp, targetFontScalePercent, targetFontMode, false);
+    }
+
+    PerAppDisplayConfig(String packageName,
+                        Integer targetViewportWidthDp,
+                        Integer targetFontScalePercent,
+                        String targetFontMode,
+                        boolean hyperOsFlutterFontHookEnabled) {
         this.packageName = packageName;
         this.viewportOverrideEnabled =
                 targetViewportWidthDp != null && targetViewportWidthDp > 0;
         this.targetViewportWidthDp = viewportOverrideEnabled ? targetViewportWidthDp : 0;
         this.targetFontScalePercent = targetFontScalePercent;
         this.targetFontMode = FontApplyMode.normalize(targetFontMode);
+        this.hyperOsFlutterFontHookEnabled = hyperOsFlutterFontHookEnabled;
     }
 
     boolean hasViewportOverride() {

--- a/app/src/main/java/com/dpis/module/PerAppDisplayConfigSource.java
+++ b/app/src/main/java/com/dpis/module/PerAppDisplayConfigSource.java
@@ -4,13 +4,25 @@ import java.util.Collections;
 import java.util.Set;
 
 final class PerAppDisplayConfigSource {
-    private final DpiConfigStore store;
+    interface StoreProvider {
+        DpiConfigStore get();
+    }
+
+    private final StoreProvider storeProvider;
 
     PerAppDisplayConfigSource(DpiConfigStore store) {
-        this.store = store;
+        this(() -> store);
+    }
+
+    PerAppDisplayConfigSource(StoreProvider storeProvider) {
+        this.storeProvider = storeProvider;
     }
 
     PerAppDisplayConfig get(String packageName) {
+        DpiConfigStore store = getStore();
+        if (store != null && !store.isTargetDpisEnabled(packageName)) {
+            return null;
+        }
         Integer targetViewportWidthDp = TargetViewportWidthResolver.resolve(store, packageName);
         Integer targetFontScalePercent = store != null
                 ? store.getTargetFontScalePercent(packageName)
@@ -24,10 +36,12 @@ final class PerAppDisplayConfigSource {
             return null;
         }
         return new PerAppDisplayConfig(packageName, targetViewportWidthDp,
-                targetFontScalePercent, targetFontMode);
+                targetFontScalePercent, targetFontMode,
+                store != null && store.isHyperOsFlutterFontHookEnabled());
     }
 
     Set<String> getConfiguredPackages() {
+        DpiConfigStore store = getStore();
         if (store == null) {
             return Collections.emptySet();
         }
@@ -35,7 +49,12 @@ final class PerAppDisplayConfigSource {
     }
 
     boolean isSystemServerHooksEnabled() {
+        DpiConfigStore store = getStore();
         return store == null || store.isSystemServerHooksEnabled();
+    }
+
+    private DpiConfigStore getStore() {
+        return storeProvider != null ? storeProvider.get() : null;
     }
 }
 

--- a/app/src/main/java/com/dpis/module/SystemServerDisplayDiagnostics.java
+++ b/app/src/main/java/com/dpis/module/SystemServerDisplayDiagnostics.java
@@ -156,7 +156,8 @@ final class SystemServerDisplayDiagnostics {
         return "config{widthDp=" + configuration.screenWidthDp
                 + ",heightDp=" + configuration.screenHeightDp
                 + ",smallestWidthDp=" + configuration.smallestScreenWidthDp
-                + ",densityDpi=" + configuration.densityDpi + "}";
+                + ",densityDpi=" + configuration.densityDpi
+                + ",fontScale=" + configuration.fontScale + "}";
     }
 
     static String describeFrame(Rect frame) {

--- a/app/src/main/java/com/dpis/module/SystemServerDisplayEnvironmentInstaller.java
+++ b/app/src/main/java/com/dpis/module/SystemServerDisplayEnvironmentInstaller.java
@@ -1,8 +1,11 @@
 package com.dpis.module;
 
 import android.content.res.Configuration;
+import android.content.pm.ActivityInfo;
 import android.graphics.Rect;
+import android.os.Binder;
 
+import java.lang.reflect.Constructor;
 import java.lang.reflect.Field;
 import java.lang.reflect.Method;
 import java.lang.reflect.Modifier;
@@ -57,6 +60,15 @@ final class SystemServerDisplayEnvironmentInstaller {
                             "computeScreenConfiguration",
                             "updateDisplayAndOrientation",
                             "getDisplayInfo"
+                    }),
+            new HookTarget("display-manager-info",
+                    new String[]{
+                            "com.android.server.display.DisplayManagerService$BinderService",
+                            "com.android.server.display.DisplayManagerService"
+                    },
+                    new String[]{
+                            "getDisplayInfo",
+                            "getDisplayInfoInternal"
                     })
     };
     private static volatile boolean installed;
@@ -94,10 +106,21 @@ final class SystemServerDisplayEnvironmentInstaller {
                     installed = true;
                     return;
                 }
-                PerAppDisplayConfigSource source = new PerAppDisplayConfigSource(store);
+                PerAppDisplayConfigSource source = new PerAppDisplayConfigSource(
+                        () -> ConfigStoreFactory.createForXposedHost(xposed));
                 Set<String> configuredPackages = source.getConfiguredPackages();
                 int installedCount = 0;
                 int missingCount = 0;
+                if (installLaunchActivityItemHook(xposed, source)) {
+                    installedCount++;
+                } else {
+                    missingCount++;
+                }
+                if (HyperOsRustProcessHookInstaller.install(xposed, source)) {
+                    installedCount++;
+                } else {
+                    missingCount++;
+                }
                 for (HookTarget target : HOOK_TARGETS) {
                     if (!SystemServerMutationPolicy.shouldInstallTarget(
                             target.entryName, policy.systemServerSafeModeEnabled)) {
@@ -178,12 +201,19 @@ final class SystemServerDisplayEnvironmentInstaller {
                                     if (!source.isSystemServerHooksEnabled()) {
                                         return chain.proceed();
                                     }
+                                    if ("display-manager-info".equals(target.entryName)) {
+                                        Object displayManagerResult = chain.proceed();
+                                        applyDisplayManagerInfoResult(
+                                                source, target.entryName, displayManagerResult);
+                                        return displayManagerResult;
+                                    }
                                     boolean loggingEnabled = DpisLog.isLoggingEnabled();
+                                    Set<String> currentConfiguredPackages = source.getConfiguredPackages();
                                     if (!shouldInspectHotEntry(
                                             target.entryName,
                                             thisObject,
                                             args,
-                                            configuredPackages)) {
+                                            currentConfiguredPackages)) {
                                         return chain.proceed();
                                     }
                                     if (loggingEnabled && shouldLogInterceptEnter(target.entryName)) {
@@ -192,7 +222,7 @@ final class SystemServerDisplayEnvironmentInstaller {
                                     ResolvedPackage resolvedPackage = resolveConfiguredPackage(
                                             thisObject,
                                             args,
-                                            packageName -> selectViewportConfigForSystemServer(
+                                            packageName -> selectConfigForSystemServer(
                                                     source.get(packageName)));
                                     if (resolvedPackage.packageName == null) {
                                         if (loggingEnabled) {
@@ -218,9 +248,8 @@ final class SystemServerDisplayEnvironmentInstaller {
                                     Snapshot before = captureSnapshot(thisObject, args);
                                     PerAppDisplayEnvironment preEnvironment = resolveTargetEnvironment(
                                             before, before, config);
-                                    if (preEnvironment != null
-                                            && shouldApplyPreProceedMutations(target.entryName)) {
-                                        applyEnvironment(target.entryName, before, preEnvironment);
+                                    if (shouldApplyPreProceedMutations(target.entryName)) {
+                                        applyEnvironment(target.entryName, before, preEnvironment, config);
                                     }
                                     result = chain.proceed();
                                     proceeded = true;
@@ -244,12 +273,12 @@ final class SystemServerDisplayEnvironmentInstaller {
                                                             after.configuration, after.frame));
                                         }
                                     }
-                                    if (effectiveEnvironment != null && shouldApplyPostProceedMutations(target.entryName)) {
+                                    if (shouldApplyPostProceedMutations(target.entryName)) {
                                         String beforeApplySummary = loggingEnabled
                                                 ? SystemServerDisplayDiagnostics.describeState(
                                                 after.configuration, after.frame)
                                                 : null;
-                                        if (applyEnvironment(target.entryName, after, effectiveEnvironment)) {
+                                        if (applyEnvironment(target.entryName, after, effectiveEnvironment, config)) {
                                             if (loggingEnabled) {
                                                 String afterApplySummary = SystemServerDisplayDiagnostics.describeState(
                                                         mutated.configuration, mutated.frame);
@@ -318,6 +347,119 @@ final class SystemServerDisplayEnvironmentInstaller {
         DpisLog.i(SystemServerDisplayDiagnostics.buildHookMissingLog(
                 target.entryName, target.describeClassNames(), target.describeMethodNames()));
         return false;
+    }
+
+    private static boolean installLaunchActivityItemHook(XposedInterface xposed,
+                                                         PerAppDisplayConfigSource source) {
+        Class<?> clazz = resolveClass("android.app.servertransaction.LaunchActivityItem", null);
+        if (clazz == null) {
+            DpisLog.i("system_server hook missing: entry=launch-activity-item, class=LaunchActivityItem");
+            return false;
+        }
+        boolean hooked = false;
+        for (Constructor<?> constructor : clazz.getDeclaredConstructors()) {
+            xposed.hook(constructor)
+                    .setExceptionMode(XposedInterface.ExceptionMode.PROTECTIVE)
+                    .intercept(chain -> {
+                        try {
+                            if (source.isSystemServerHooksEnabled()) {
+                                applyLaunchActivityItemArgs(source, chain.getArgs());
+                            }
+                        } catch (Throwable throwable) {
+                            DpisLog.e("system_server launch-activity-item failed", throwable);
+                        }
+                        return chain.proceed();
+                    });
+            hooked = true;
+        }
+        if (hooked) {
+            DpisLog.i("system_server hook ready: entry=launch-activity-item, class=LaunchActivityItem");
+        }
+        return hooked;
+    }
+
+    private static void applyLaunchActivityItemArgs(PerAppDisplayConfigSource source,
+                                                    List<Object> args) {
+        String packageName = findActivityInfoPackage(args);
+        if (packageName == null) {
+            return;
+        }
+        PerAppDisplayConfig config = selectConfigForSystemServer(source.get(packageName));
+        if (config == null) {
+            return;
+        }
+        Configuration baseConfiguration = findFirstConfiguration(args);
+        if (baseConfiguration == null) {
+            return;
+        }
+        PerAppDisplayEnvironment environment = null;
+        if (config.hasViewportOverride()) {
+            int widthPx = resolveWidthPx(baseConfiguration, null);
+            int heightPx = resolveHeightPx(baseConfiguration, null);
+            environment = PerAppDisplayOverrideCalculator.calculate(
+                    baseConfiguration, widthPx, heightPx, config.targetViewportWidthDp);
+        }
+        String beforeSummary = DpisLog.isLoggingEnabled()
+                ? describeConfigurationArgs(args)
+                : null;
+        float beforeFontScale = baseConfiguration.fontScale;
+        boolean changed = false;
+        boolean fontChanged = false;
+        for (Object arg : args) {
+            if (arg instanceof Configuration configuration) {
+                if (environment != null) {
+                    changed |= applyConfiguration(configuration, environment);
+                }
+                boolean appliedFont = applyFontScale(configuration, config);
+                fontChanged |= appliedFont;
+                changed |= appliedFont;
+            }
+        }
+        if (fontChanged) {
+            HyperOsFlutterFontBridge.publishTarget(packageName, config);
+            reportSystemServerFontConfig(packageName, beforeFontScale, baseConfiguration.fontScale);
+        }
+        if (changed && DpisLog.isLoggingEnabled()) {
+            String message = "system_server launch-activity-item apply: package=" + packageName
+                    + ", before=" + safeToString(beforeSummary)
+                    + ", after=" + describeConfigurationArgs(args)
+                    + ", target=" + describeEnvironment(environment);
+            logIfChanged("launch-activity-item|" + packageName, message,
+                    resolveLogMinIntervalMs("launch-activity-item"));
+        }
+    }
+
+    private static String findActivityInfoPackage(List<Object> args) {
+        for (Object arg : args) {
+            if (arg instanceof ActivityInfo activityInfo
+                    && activityInfo.packageName != null
+                    && isLikelyPackageName(activityInfo.packageName)) {
+                return activityInfo.packageName;
+            }
+        }
+        return null;
+    }
+
+    private static Configuration findFirstConfiguration(List<Object> args) {
+        for (Object arg : args) {
+            if (arg instanceof Configuration configuration) {
+                return configuration;
+            }
+        }
+        return null;
+    }
+
+    private static String describeConfigurationArgs(List<Object> args) {
+        StringJoiner joiner = new StringJoiner(",");
+        int index = 0;
+        for (Object arg : args) {
+            if (arg instanceof Configuration configuration) {
+                joiner.add("#" + index + "="
+                        + SystemServerDisplayDiagnostics.describeConfiguration(configuration));
+            }
+            index++;
+        }
+        return joiner.toString();
     }
 
     private static Set<ClassLoader> resolveCandidateClassLoaders() {
@@ -587,7 +729,7 @@ final class SystemServerDisplayEnvironmentInstaller {
     private static PerAppDisplayEnvironment resolveTargetEnvironment(Snapshot before,
                                                                      Snapshot after,
                                                                      PerAppDisplayConfig config) {
-        if (config == null) {
+        if (config == null || !config.hasViewportOverride()) {
             return null;
         }
         Configuration configuration = after.configuration != null
@@ -630,12 +772,151 @@ final class SystemServerDisplayEnvironmentInstaller {
                 entryName, self, args, configuredPackages);
     }
 
-    private static PerAppDisplayConfig selectViewportConfigForSystemServer(
+    private static PerAppDisplayConfig selectConfigForSystemServer(
             PerAppDisplayConfig config) {
-        if (config == null || !config.hasViewportOverride()) {
+        if (config == null
+                || (!config.hasViewportOverride() && !hasSystemServerFontOverride(config))) {
             return null;
         }
         return config;
+    }
+
+    private static boolean hasSystemServerFontOverride(PerAppDisplayConfig config) {
+        return config != null
+                && FontApplyMode.SYSTEM_EMULATION.equals(config.targetFontMode)
+                && config.targetFontScalePercent != null
+                && config.targetFontScalePercent > 0;
+    }
+
+    private static void applyDisplayManagerInfoResult(PerAppDisplayConfigSource source,
+                                                       String entryName,
+                                                       Object displayInfo) {
+        if (displayInfo == null || source == null) {
+            logDisplayManagerInfoSkip(entryName, "empty-result", -1, null, displayInfo);
+            return;
+        }
+        int callingUid = Binder.getCallingUid();
+        String packageName = resolveCallingUidConfiguredPackage(source, callingUid);
+        if (packageName == null) {
+            logDisplayManagerInfoSkip(entryName, "uid-not-configured", callingUid, null, displayInfo);
+            return;
+        }
+        PerAppDisplayConfig config = selectConfigForSystemServer(source.get(packageName));
+        if (config == null) {
+            logDisplayManagerInfoSkip(entryName, "no-viewport-config", callingUid, packageName, displayInfo);
+            return;
+        }
+        PerAppDisplayEnvironment environment = resolveDisplayInfoEnvironment(displayInfo, config);
+        if (environment == null) {
+            logDisplayManagerInfoSkip(entryName, "env-null", callingUid, packageName, displayInfo);
+            return;
+        }
+        String beforeSummary = DpisLog.isLoggingEnabled() ? describeDisplayInfo(displayInfo) : null;
+        if (!applyDisplayInfo(displayInfo, environment)) {
+            return;
+        }
+        if (DpisLog.isLoggingEnabled()) {
+            String message = "system_server display-manager-info apply: package=" + packageName
+                    + ", before=" + safeToString(beforeSummary)
+                    + ", after=" + safeToString(describeDisplayInfo(displayInfo))
+                    + ", target=" + describeEnvironment(environment);
+            logIfChanged("display-manager-info|" + packageName, message,
+                    resolveLogMinIntervalMs(entryName));
+        }
+    }
+
+    private static void logDisplayManagerInfoSkip(String entryName,
+                                                  String reason,
+                                                  int callingUid,
+                                                  String packageName,
+                                                  Object displayInfo) {
+        if (!DpisLog.isLoggingEnabled()) {
+            return;
+        }
+        String message = "system_server display-manager-info skip: reason=" + reason
+                + ", uid=" + callingUid
+                + ", package=" + safeToString(packageName)
+                + ", displayInfo=" + safeToString(describeDisplayInfo(displayInfo));
+        logIfChanged("display-manager-info-skip|" + reason + "|" + callingUid,
+                message, resolveLogMinIntervalMs(entryName));
+    }
+
+    private static String resolveCallingUidConfiguredPackage(PerAppDisplayConfigSource source,
+                                                             int callingUid) {
+        if (callingUid <= 0) {
+            return null;
+        }
+        String fallbackPackage = null;
+        for (String packageName : source.getConfiguredPackages()) {
+            if (resolvePackageUid(packageName) != callingUid) {
+                continue;
+            }
+            if (selectConfigForSystemServer(source.get(packageName)) != null) {
+                return packageName;
+            }
+            fallbackPackage = packageName;
+        }
+        return fallbackPackage;
+    }
+
+    private static int resolvePackageUid(String packageName) {
+        try {
+            Object packageManager = Class.forName("android.app.AppGlobals")
+                    .getMethod("getPackageManager")
+                    .invoke(null);
+            if (packageManager != null) {
+                Object uid = packageManager.getClass()
+                        .getMethod("getPackageUid", String.class, long.class, int.class)
+                        .invoke(packageManager, packageName, 0L, 0);
+                if (uid instanceof Integer integerUid) {
+                    return integerUid;
+                }
+            }
+        } catch (Throwable throwable) {
+            try {
+                Object activityThread = Class.forName("android.app.ActivityThread")
+                        .getMethod("currentActivityThread")
+                        .invoke(null);
+                if (activityThread == null) {
+                    return -1;
+                }
+                Object context = activityThread.getClass()
+                        .getMethod("getSystemContext")
+                        .invoke(activityThread);
+                if (!(context instanceof android.content.Context androidContext)) {
+                    return -1;
+                }
+                return androidContext.getPackageManager().getPackageUid(packageName, 0);
+            } catch (Throwable ignored) {
+                return -1;
+            }
+        }
+        return -1;
+    }
+
+    private static PerAppDisplayEnvironment resolveDisplayInfoEnvironment(Object displayInfo,
+                                                                          PerAppDisplayConfig config) {
+        Integer logicalWidth = readIntField(displayInfo, "logicalWidth");
+        Integer logicalHeight = readIntField(displayInfo, "logicalHeight");
+        Integer logicalDensityDpi = readIntField(displayInfo, "logicalDensityDpi");
+        if (logicalWidth == null || logicalHeight == null || logicalDensityDpi == null
+                || logicalWidth <= 0 || logicalHeight <= 0 || logicalDensityDpi <= 0) {
+            return null;
+        }
+        Configuration configuration = new Configuration();
+        configuration.densityDpi = logicalDensityDpi;
+        configuration.screenWidthDp = Math.max(1,
+                Math.round(logicalWidth / (logicalDensityDpi / 160.0f)));
+        configuration.screenHeightDp = Math.max(1,
+                Math.round(logicalHeight / (logicalDensityDpi / 160.0f)));
+        configuration.smallestScreenWidthDp = Math.min(
+                configuration.screenWidthDp,
+                configuration.screenHeightDp);
+        return PerAppDisplayOverrideCalculator.calculate(
+                configuration,
+                logicalWidth,
+                logicalHeight,
+                config.targetViewportWidthDp);
     }
 
     private static PerAppDisplayEnvironment chooseEffectiveEnvironment(
@@ -670,7 +951,7 @@ final class SystemServerDisplayEnvironmentInstaller {
     }
 
     static boolean shouldUseConfigInSystemServerForTest(PerAppDisplayConfig config) {
-        return selectViewportConfigForSystemServer(config) != null;
+        return selectConfigForSystemServer(config) != null;
     }
 
     static boolean shouldEmitLogForTest(String previousMessage,
@@ -687,15 +968,23 @@ final class SystemServerDisplayEnvironmentInstaller {
 
     private static boolean applyEnvironment(String entryName,
                                             Snapshot snapshot,
-                                            PerAppDisplayEnvironment environment) {
+                                            PerAppDisplayEnvironment environment,
+                                            PerAppDisplayConfig config) {
         boolean changed = false;
-        if (snapshot.configuration != null) {
+        if (snapshot.configuration != null && environment != null) {
             changed |= applyConfiguration(snapshot.configuration, environment);
         }
-        if (shouldApplyFrame(entryName) && snapshot.frame != null) {
+        if (snapshot.configuration != null) {
+            boolean fontChanged = applyFontScale(snapshot.configuration, config);
+            if (fontChanged) {
+                HyperOsFlutterFontBridge.publishTarget(config.packageName, config);
+            }
+            changed |= fontChanged;
+        }
+        if (environment != null && shouldApplyFrame(entryName) && snapshot.frame != null) {
             changed |= applyFrame(snapshot.frame, environment.widthPx, environment.heightPx);
         }
-        if (shouldApplyDisplayInfo(entryName) && snapshot.displayInfo != null) {
+        if (environment != null && shouldApplyDisplayInfo(entryName) && snapshot.displayInfo != null) {
             changed |= applyDisplayInfo(snapshot.displayInfo, environment);
         }
         return changed;
@@ -725,6 +1014,29 @@ final class SystemServerDisplayEnvironmentInstaller {
                 environment.smallestWidthDp,
                 environment.densityDpi));
         return true;
+    }
+
+    private static boolean applyFontScale(Configuration configuration,
+                                          PerAppDisplayConfig config) {
+        if (configuration == null || !hasSystemServerFontOverride(config)) {
+            return false;
+        }
+        float fontScale = config.targetFontScalePercent / 100.0f;
+        if (Math.abs(configuration.fontScale - fontScale) < 0.0001f) {
+            return false;
+        }
+        configuration.fontScale = fontScale;
+        return true;
+    }
+
+    private static void reportSystemServerFontConfig(String packageName,
+                                                     float beforeFontScale,
+                                                     float afterFontScale) {
+        if (packageName == null || packageName.isEmpty()) {
+            return;
+        }
+        DpisLog.i("DPIS_FONT SystemServer config fontScale: package=" + packageName
+                + ", fontScale=" + beforeFontScale + "->" + afterFontScale);
     }
 
     private static boolean applyFrame(Rect frame, int targetWidthPx, int targetHeightPx) {

--- a/app/src/main/java/com/dpis/module/SystemServerDisplayEnvironmentInstaller.java
+++ b/app/src/main/java/com/dpis/module/SystemServerDisplayEnvironmentInstaller.java
@@ -111,15 +111,21 @@ final class SystemServerDisplayEnvironmentInstaller {
                 Set<String> configuredPackages = source.getConfiguredPackages();
                 int installedCount = 0;
                 int missingCount = 0;
-                if (installLaunchActivityItemHook(xposed, source)) {
-                    installedCount++;
-                } else {
-                    missingCount++;
+                if (shouldInstallTarget("launch-activity-item",
+                        policy.systemServerSafeModeEnabled)) {
+                    if (installLaunchActivityItemHook(xposed, source)) {
+                        installedCount++;
+                    } else {
+                        missingCount++;
+                    }
                 }
-                if (HyperOsRustProcessHookInstaller.install(xposed, source)) {
-                    installedCount++;
-                } else {
-                    missingCount++;
+                if (shouldInstallTarget("hyperos-rust-process",
+                        policy.systemServerSafeModeEnabled)) {
+                    if (HyperOsRustProcessHookInstaller.install(xposed, source)) {
+                        installedCount++;
+                    } else {
+                        missingCount++;
+                    }
                 }
                 for (HookTarget target : HOOK_TARGETS) {
                     if (!SystemServerMutationPolicy.shouldInstallTarget(

--- a/app/src/main/java/com/dpis/module/SystemServerSettingsActivity.java
+++ b/app/src/main/java/com/dpis/module/SystemServerSettingsActivity.java
@@ -61,6 +61,7 @@ public final class SystemServerSettingsActivity extends LocalizedActivity
     private MaterialSwitch hooksEnabledSwitch;
     private MaterialSwitch safeModeSwitch;
     private MaterialSwitch globalLogSwitch;
+    private MaterialSwitch hyperOsFlutterFontHookSwitch;
     private MaterialSwitch hideLauncherIconSwitch;
     private View primarySwitchCard;
     private View languageEntryRow;
@@ -119,6 +120,11 @@ public final class SystemServerSettingsActivity extends LocalizedActivity
                 R.string.font_debug_overlay_label,
                 R.string.font_debug_entry_hint,
                 this::showFontDebugDialog);
+        hyperOsFlutterFontHookSwitch = bindSwitchRow(
+                R.id.row_hyperos_flutter_font_hook,
+                R.drawable.baseline_tune_24,
+                R.string.settings_hyperos_flutter_font_hook_label,
+                R.string.settings_hyperos_flutter_font_hook_hint);
         backupConfigEntryRow = bindEntryRow(
                 R.id.row_config_backup,
                 R.drawable.baseline_upload_file_24,
@@ -148,6 +154,7 @@ public final class SystemServerSettingsActivity extends LocalizedActivity
         hooksEnabledSwitch.setOnCheckedChangeListener(this::onHooksEnabledChanged);
         safeModeSwitch.setOnCheckedChangeListener(this::onSafeModeChanged);
         globalLogSwitch.setOnCheckedChangeListener(this::onGlobalLogChanged);
+        hyperOsFlutterFontHookSwitch.setOnCheckedChangeListener(this::onHyperOsFlutterFontHookChanged);
         hideLauncherIconSwitch.setOnCheckedChangeListener(this::onHideLauncherIconChanged);
         refreshStoreState(true);
     }
@@ -479,6 +486,9 @@ public final class SystemServerSettingsActivity extends LocalizedActivity
         setCheckedSilently(globalLogSwitch,
                 store.isGlobalLogEnabled(),
                 this::onGlobalLogChanged);
+        setCheckedSilently(hyperOsFlutterFontHookSwitch,
+                store.isHyperOsFlutterFontHookEnabled(),
+                this::onHyperOsFlutterFontHookChanged);
         DpisLog.setLoggingEnabled(store.isGlobalLogEnabled());
 
         applyLauncherIconVisibilityFromStore();
@@ -506,6 +516,7 @@ public final class SystemServerSettingsActivity extends LocalizedActivity
         hooksEnabledSwitch.setEnabled(true);
         safeModeSwitch.setEnabled(true);
         globalLogSwitch.setEnabled(true);
+        hyperOsFlutterFontHookSwitch.setEnabled(true);
         hideLauncherIconSwitch.setEnabled(true);
         setRowEnabled(fontDebugEntryRow, true);
         setRowEnabled(backupConfigEntryRow, true);
@@ -523,6 +534,7 @@ public final class SystemServerSettingsActivity extends LocalizedActivity
         hooksEnabledSwitch.setEnabled(false);
         safeModeSwitch.setEnabled(false);
         globalLogSwitch.setEnabled(false);
+        hyperOsFlutterFontHookSwitch.setEnabled(false);
         hideLauncherIconSwitch.setEnabled(false);
         setRowEnabled(fontDebugEntryRow, false);
         setRowEnabled(backupConfigEntryRow, false);
@@ -834,6 +846,17 @@ public final class SystemServerSettingsActivity extends LocalizedActivity
             return;
         }
         DpisLog.setLoggingEnabled(isChecked);
+    }
+
+    private void onHyperOsFlutterFontHookChanged(CompoundButton buttonView, boolean isChecked) {
+        if (store == null) {
+            return;
+        }
+        if (!store.setHyperOsFlutterFontHookEnabled(isChecked)) {
+            setCheckedSilently(hyperOsFlutterFontHookSwitch, !isChecked,
+                    this::onHyperOsFlutterFontHookChanged);
+            showToast(R.string.system_settings_save_failed);
+        }
     }
 
     private void onHideLauncherIconChanged(CompoundButton buttonView, boolean isChecked) {

--- a/app/src/main/java/com/dpis/module/SystemServerSettingsActivity.java
+++ b/app/src/main/java/com/dpis/module/SystemServerSettingsActivity.java
@@ -856,6 +856,10 @@ public final class SystemServerSettingsActivity extends LocalizedActivity
             setCheckedSilently(hyperOsFlutterFontHookSwitch, !isChecked,
                     this::onHyperOsFlutterFontHookChanged);
             showToast(R.string.system_settings_save_failed);
+            return;
+        }
+        if (!isChecked) {
+            HyperOsNativeFontPropertySyncer.clearConfiguredFontTargetsAsync(store);
         }
     }
 

--- a/app/src/main/java/com/dpis/module/TargetViewportWidthResolver.java
+++ b/app/src/main/java/com/dpis/module/TargetViewportWidthResolver.java
@@ -8,6 +8,10 @@ final class TargetViewportWidthResolver {
         if (store == null || packageName == null || packageName.isEmpty()) {
             return null;
         }
+        Integer runtimeOverride = ViewportPropertyBridge.readTargetWidthDp(packageName);
+        if (runtimeOverride != null) {
+            return runtimeOverride > 0 ? runtimeOverride : null;
+        }
         String requestedMode = store.getTargetViewportApplyMode(packageName);
         String mode = EffectiveModeResolver.resolveViewportMode(
                 requestedMode,

--- a/app/src/main/java/com/dpis/module/ViewportDebugReporter.java
+++ b/app/src/main/java/com/dpis/module/ViewportDebugReporter.java
@@ -2,7 +2,7 @@ package com.dpis.module;
 
 import android.app.Application;
 import android.content.Context;
-import android.content.Intent;
+import android.os.Bundle;
 
 import java.lang.reflect.Method;
 
@@ -48,13 +48,10 @@ final class ViewportDebugReporter {
         if (context == null) {
             return;
         }
-        Intent intent = new Intent(FontDebugStatsStore.ACTION_STATS_UPDATE);
-        // Hook callbacks execute inside target app processes; always route updates
-        // back to the module package receiver instead of target app package.
-        intent.setPackage(BuildConfig.APPLICATION_ID);
-        intent.putExtra(FontDebugStatsStore.EXTRA_VIEWPORT_DEBUG_SUMMARY, summary);
+        Bundle extras = new Bundle();
+        extras.putString(FontDebugStatsStore.EXTRA_VIEWPORT_DEBUG_SUMMARY, summary);
         try {
-            context.sendBroadcast(intent);
+            FontDebugStatsTransport.sendUpdate(context, extras);
             lastSummary = summary;
         } catch (Throwable ignored) {
         }

--- a/app/src/main/java/com/dpis/module/ViewportPropertyBridge.java
+++ b/app/src/main/java/com/dpis/module/ViewportPropertyBridge.java
@@ -1,0 +1,49 @@
+package com.dpis.module;
+
+import java.lang.reflect.Method;
+import java.util.Locale;
+
+final class ViewportPropertyBridge {
+    private static final String PROPERTY_PREFIX = "debug.dpis.vp.";
+
+    private ViewportPropertyBridge() {
+    }
+
+    static String propertyNameForPackage(String packageName) {
+        return PROPERTY_PREFIX + String.format(Locale.US, "%08x", packageName.hashCode());
+    }
+
+    static Integer readTargetWidthDp(String packageName) {
+        if (packageName == null || packageName.isEmpty()) {
+            return null;
+        }
+        return parseOverrideValue(readSystemProperty(propertyNameForPackage(packageName)));
+    }
+
+    static Integer parseOverrideValueForTest(String value) {
+        return parseOverrideValue(value);
+    }
+
+    private static Integer parseOverrideValue(String value) {
+        if (value == null || value.trim().isEmpty()) {
+            return null;
+        }
+        try {
+            int parsed = Integer.parseInt(value.trim());
+            return parsed >= 0 ? parsed : null;
+        } catch (NumberFormatException ignored) {
+            return null;
+        }
+    }
+
+    private static String readSystemProperty(String key) {
+        try {
+            Class<?> systemProperties = Class.forName("android.os.SystemProperties");
+            Method getMethod = systemProperties.getDeclaredMethod("get", String.class, String.class);
+            Object value = getMethod.invoke(null, key, "");
+            return value instanceof String ? (String) value : "";
+        } catch (Throwable ignored) {
+            return "";
+        }
+    }
+}

--- a/app/src/main/java/com/dpis/module/ViewportPropertySyncer.java
+++ b/app/src/main/java/com/dpis/module/ViewportPropertySyncer.java
@@ -1,0 +1,64 @@
+package com.dpis.module;
+
+import java.io.IOException;
+
+final class ViewportPropertySyncer {
+    private ViewportPropertySyncer() {
+    }
+
+    static void publishTargetAsync(String packageName, int widthDp) {
+        if (packageName == null || packageName.isBlank() || widthDp <= 0) {
+            return;
+        }
+        String property = ViewportPropertyBridge.propertyNameForPackage(packageName);
+        Thread publisherThread = new Thread(() -> setPropertyWithRoot(property, widthDp),
+                "DPIS-viewport-property-publisher");
+        publisherThread.setDaemon(true);
+        publisherThread.start();
+    }
+
+    static void clearTargetAsync(String packageName) {
+        if (packageName == null || packageName.isBlank()) {
+            return;
+        }
+        String property = ViewportPropertyBridge.propertyNameForPackage(packageName);
+        Thread cleanerThread = new Thread(() -> setPropertyWithRoot(property, 0),
+                "DPIS-viewport-property-cleaner");
+        cleanerThread.setDaemon(true);
+        cleanerThread.start();
+    }
+
+    static String buildSetCommandForTest(String property, int widthDp) {
+        return buildSetCommand(property, widthDp);
+    }
+
+    private static void setPropertyWithRoot(String property, int widthDp) {
+        runRootCommand(buildSetCommand(property, widthDp));
+    }
+
+    private static String buildSetCommand(String property, int widthDp) {
+        return "setprop " + shellQuote(property) + " " + shellQuote(String.valueOf(widthDp));
+    }
+
+    private static void runRootCommand(String command) {
+        Process process = null;
+        try {
+            process = Runtime.getRuntime().exec(new String[] { "su", "-c", command });
+            process.waitFor();
+        } catch (IOException ignored) {
+        } catch (InterruptedException ignored) {
+            Thread.currentThread().interrupt();
+        } finally {
+            if (process != null) {
+                process.destroy();
+            }
+        }
+    }
+
+    private static String shellQuote(String value) {
+        if (value == null || value.isEmpty()) {
+            return "''";
+        }
+        return "'" + value.replace("'", "'\\''") + "'";
+    }
+}

--- a/app/src/main/res/layout/activity_system_server_settings.xml
+++ b/app/src/main/res/layout/activity_system_server_settings.xml
@@ -33,6 +33,10 @@
                     <com.google.android.material.divider.MaterialDivider android:layout_width="match_parent" android:layout_height="wrap_content" android:layout_marginStart="16dp" android:layout_marginEnd="16dp" />
 
                     <include android:id="@+id/row_font_debug_overlay" layout="@layout/item_settings_entry" />
+
+                    <com.google.android.material.divider.MaterialDivider android:layout_width="match_parent" android:layout_height="wrap_content" android:layout_marginStart="16dp" android:layout_marginEnd="16dp" />
+
+                    <include android:id="@+id/row_hyperos_flutter_font_hook" layout="@layout/item_settings_switch" />
                 </LinearLayout>
             </com.google.android.material.card.MaterialCardView>
 

--- a/app/src/main/res/layout/dialog_app_config.xml
+++ b/app/src/main/res/layout/dialog_app_config.xml
@@ -17,6 +17,8 @@
                 <com.google.android.material.textview.MaterialTextView android:id="@+id/dialog_package" android:layout_width="match_parent" android:layout_height="wrap_content" android:layout_marginTop="1dp" android:ellipsize="middle" android:maxLines="1" android:textAppearance="@style/TextAppearance.Material3.BodyMedium" />
 
                 <com.google.android.material.textview.MaterialTextView android:id="@+id/dialog_status" android:layout_width="match_parent" android:layout_height="wrap_content" android:layout_marginTop="1dp" android:maxLines="1" android:textAppearance="@style/TextAppearance.Material3.BodySmall" />
+
+                <com.google.android.material.textview.MaterialTextView android:id="@+id/dialog_hyperos_native_warning" android:layout_width="match_parent" android:layout_height="wrap_content" android:layout_marginTop="4dp" android:text="@string/dialog_hyperos_native_warning" android:textAppearance="@style/TextAppearance.Material3.BodySmall" android:visibility="gone" />
             </LinearLayout>
         </LinearLayout>
 

--- a/app/src/main/res/values-zh-rCN/strings.xml
+++ b/app/src/main/res/values-zh-rCN/strings.xml
@@ -45,9 +45,13 @@
     <string name="dialog_dpis_enable_button">启用修改</string>
     <string name="dialog_dpis_disable_button">已启用</string>
     <string name="dialog_hyperos_native_warning">检测到 HyperOS 原生/Flutter 应用。当前 Java Hook 可能不会加载，因此 DP/字体替换可能无效。</string>
-    <string name="dialog_hyperos_native_proxy_present">HyperOS Native Proxy：已检测到。重启目标应用后可使用 Rust/Flutter 字体 Hook。</string>
-    <string name="dialog_hyperos_native_proxy_missing">HyperOS Native Proxy：目标应用 native 目录未检测到，Rust/Flutter 字体 Hook 可能不会生效。</string>
-    <string name="dialog_hyperos_native_proxy_unknown">HyperOS Native Proxy：无法检测目标应用 native 目录。若字体 Hook 不生效，请手动确认 libdpis_native.so。</string>
+    <string name="dialog_hyperos_native_proxy_present">HyperOS &#x517C;&#x5BB9;&#x652F;&#x6301;&#x5DF2;&#x5C31;&#x7EEA;&#x3002;&#x4FDD;&#x5B58;&#x4FEE;&#x6539;&#x540E;&#x8BF7;&#x91CD;&#x542F;&#x76EE;&#x6807;&#x5E94;&#x7528;&#x3002;</string>
+    <string name="dialog_hyperos_native_proxy_missing">HyperOS &#x517C;&#x5BB9;&#x652F;&#x6301;&#x5C1A;&#x672A;&#x5C31;&#x7EEA;&#xFF0C;&#x90E8;&#x5206;&#x6587;&#x5B57;&#x4FEE;&#x6539;&#x53EF;&#x80FD;&#x4E0D;&#x4F1A;&#x751F;&#x6548;&#x3002;</string>
+    <string name="dialog_hyperos_native_proxy_unknown">&#x65E0;&#x6CD5;&#x68C0;&#x67E5; HyperOS &#x517C;&#x5BB9;&#x652F;&#x6301;&#x72B6;&#x6001;&#x3002;</string>
+    <string name="dialog_hyperos_native_proxy_apply_success">HyperOS &#x517C;&#x5BB9;&#x652F;&#x6301;&#x5DF2;&#x5E94;&#x7528;&#xFF0C;&#x8BF7;&#x91CD;&#x542F;&#x76EE;&#x6807;&#x5E94;&#x7528;&#x3002;</string>
+    <string name="dialog_hyperos_native_proxy_apply_failed">HyperOS &#x517C;&#x5BB9;&#x8BBE;&#x7F6E;&#x5931;&#x8D25;&#xFF0C;&#x8BF7;&#x68C0;&#x67E5; root &#x6743;&#x9650;&#x540E;&#x91CD;&#x8BD5;&#x3002;</string>
+    <string name="dialog_hyperos_native_proxy_unmount_success">HyperOS &#x517C;&#x5BB9;&#x652F;&#x6301;&#x5DF2;&#x56DE;&#x6EDA;&#xFF0C;&#x8BF7;&#x91CD;&#x542F;&#x76EE;&#x6807;&#x5E94;&#x7528;&#x3002;</string>
+    <string name="dialog_hyperos_native_proxy_unmount_failed">HyperOS &#x517C;&#x5BB9;&#x56DE;&#x6EDA;&#x5931;&#x8D25;&#xFF0C;&#x8BF7;&#x68C0;&#x67E5; root &#x6743;&#x9650;&#x540E;&#x91CD;&#x8BD5;&#x3002;</string>
     <string name="module_runtime_reload_title">系统级 Hook 可能需要重载</string>
     <string name="module_runtime_reload_message">DPIS 是在本次开机后更新的。普通 Java 应用重启目标应用后通常可以生效，但 system_server/HyperOS Rust 链路可能仍在运行旧模块代码。如果相册或其他 HyperOS 应用没有变化，请重启设备，或重启模块运行时/system_server 后再测试。</string>
     <string name="module_runtime_reload_ack_button">知道了</string>

--- a/app/src/main/res/values-zh-rCN/strings.xml
+++ b/app/src/main/res/values-zh-rCN/strings.xml
@@ -44,6 +44,13 @@
     <string name="dialog_stop_button">停止</string>
     <string name="dialog_dpis_enable_button">启用修改</string>
     <string name="dialog_dpis_disable_button">已启用</string>
+    <string name="dialog_hyperos_native_warning">检测到 HyperOS 原生/Flutter 应用。当前 Java Hook 可能不会加载，因此 DP/字体替换可能无效。</string>
+    <string name="dialog_hyperos_native_proxy_present">HyperOS Native Proxy：已检测到。重启目标应用后可使用 Rust/Flutter 字体 Hook。</string>
+    <string name="dialog_hyperos_native_proxy_missing">HyperOS Native Proxy：目标应用 native 目录未检测到，Rust/Flutter 字体 Hook 可能不会生效。</string>
+    <string name="dialog_hyperos_native_proxy_unknown">HyperOS Native Proxy：无法检测目标应用 native 目录。若字体 Hook 不生效，请手动确认 libdpis_native.so。</string>
+    <string name="module_runtime_reload_title">系统级 Hook 可能需要重载</string>
+    <string name="module_runtime_reload_message">DPIS 是在本次开机后更新的。普通 Java 应用重启目标应用后通常可以生效，但 system_server/HyperOS Rust 链路可能仍在运行旧模块代码。如果相册或其他 HyperOS 应用没有变化，请重启设备，或重启模块运行时/system_server 后再测试。</string>
+    <string name="module_runtime_reload_ack_button">知道了</string>
     <string name="dialog_process_requires_root">该操作需要 root 权限</string>
     <string name="dialog_process_restart_requires_root">重启应用需要 root 权限</string>
     <string name="dialog_process_stop_requires_root">停止应用需要 root 权限</string>
@@ -107,6 +114,8 @@
     <string name="font_debug_reason_not_injected_hint">目标进程未加载模块，检查 LSPosed 启用状态并重启目标应用。</string>
     <string name="font_debug_reason_no_events">无事件</string>
     <string name="font_debug_reason_no_events_hint">已注入但未命中字体链路，进入文字页面或切到累计窗口观察。</string>
+    <string name="settings_hyperos_flutter_font_hook_label">实验性 HyperOS Flutter 字体 Hook</string>
+    <string name="settings_hyperos_flutter_font_hook_hint">针对 HyperOS Flutter 应用的 native 文本层 Hook，需重启目标应用。</string>
     <string name="settings_about_label">关于</string>
     <string name="settings_about_hint">查看版本、源码与反馈渠道。</string>
     <string name="settings_config_backup_label">配置备份</string>

--- a/app/src/main/res/values-zh-rCN/strings.xml
+++ b/app/src/main/res/values-zh-rCN/strings.xml
@@ -53,7 +53,11 @@
     <string name="dialog_hyperos_native_proxy_unmount_success">HyperOS &#x517C;&#x5BB9;&#x652F;&#x6301;&#x5DF2;&#x56DE;&#x6EDA;&#xFF0C;&#x8BF7;&#x91CD;&#x542F;&#x76EE;&#x6807;&#x5E94;&#x7528;&#x3002;</string>
     <string name="dialog_hyperos_native_proxy_unmount_failed">HyperOS &#x517C;&#x5BB9;&#x56DE;&#x6EDA;&#x5931;&#x8D25;&#xFF0C;&#x8BF7;&#x68C0;&#x67E5; root &#x6743;&#x9650;&#x540E;&#x91CD;&#x8BD5;&#x3002;</string>
     <string name="module_runtime_reload_title">系统级 Hook 可能需要重载</string>
-    <string name="module_runtime_reload_message">DPIS 是在本次开机后更新的。普通 Java 应用重启目标应用后通常可以生效，但 system_server/HyperOS Rust 链路可能仍在运行旧模块代码。如果相册或其他 HyperOS 应用没有变化，请重启设备，或重启模块运行时/system_server 后再测试。</string>
+    <string name="module_runtime_reload_message">DPIS 是在本次开机后更新的。普通 Java 应用重启目标应用后通常可以生效，但 system_server/HyperOS Rust 链路可能仍在运行旧模块代码。要在不完整重启设备的情况下应用新的 HyperOS 兼容代码，请立即重载模块运行时。这会短暂重启 Android 系统服务。</string>
+    <string name="module_runtime_reload_now_button">立即重载</string>
+    <string name="module_runtime_reload_later_button">稍后</string>
+    <string name="module_runtime_reload_started">正在重载 Android 运行时…</string>
+    <string name="module_runtime_reload_failed">运行时重载失败，请检查 root 权限或重启设备。</string>
     <string name="module_runtime_reload_ack_button">知道了</string>
     <string name="dialog_process_requires_root">该操作需要 root 权限</string>
     <string name="dialog_process_restart_requires_root">重启应用需要 root 权限</string>

--- a/app/src/main/res/values/strings.xml
+++ b/app/src/main/res/values/strings.xml
@@ -45,9 +45,13 @@
     <string name="dialog_dpis_enable_button">Enable</string>
     <string name="dialog_dpis_disable_button">Enabled</string>
     <string name="dialog_hyperos_native_warning">HyperOS native/Flutter app detected. Current Java hooks may not load, so DP/font replacement can be ineffective.</string>
-    <string name="dialog_hyperos_native_proxy_present">HyperOS Native Proxy: detected. Rust/Flutter font hook can be used after restarting the target app.</string>
-    <string name="dialog_hyperos_native_proxy_missing">HyperOS Native Proxy: not detected in the target app native directory, so Rust/Flutter font hook may not take effect.</string>
-    <string name="dialog_hyperos_native_proxy_unknown">HyperOS Native Proxy: unable to check the target app native directory. If font hook does not work, verify libdpis_native.so manually.</string>
+    <string name="dialog_hyperos_native_proxy_present">HyperOS compatibility support is ready. Restart the target app after saving changes.</string>
+    <string name="dialog_hyperos_native_proxy_missing">HyperOS compatibility support is not ready for this app. Some text changes may not take effect.</string>
+    <string name="dialog_hyperos_native_proxy_unknown">HyperOS compatibility support status could not be checked.</string>
+    <string name="dialog_hyperos_native_proxy_apply_success">HyperOS compatibility support applied. Restart the target app.</string>
+    <string name="dialog_hyperos_native_proxy_apply_failed">HyperOS compatibility setup failed. Check root access and try again.</string>
+    <string name="dialog_hyperos_native_proxy_unmount_success">HyperOS compatibility support rolled back. Restart the target app.</string>
+    <string name="dialog_hyperos_native_proxy_unmount_failed">HyperOS compatibility rollback failed. Check root access and try again.</string>
     <string name="module_runtime_reload_title">System-level hooks may need reload</string>
     <string name="module_runtime_reload_message">DPIS was updated after this boot. Normal Java app hooks may work after restarting the target app, but system_server/HyperOS Rust hooks can still be running the previous module code. If Gallery or other HyperOS apps do not change, reboot the device or restart the module runtime/system_server before testing.</string>
     <string name="module_runtime_reload_ack_button">Got it</string>

--- a/app/src/main/res/values/strings.xml
+++ b/app/src/main/res/values/strings.xml
@@ -44,6 +44,13 @@
     <string name="dialog_stop_button">Stop</string>
     <string name="dialog_dpis_enable_button">Enable</string>
     <string name="dialog_dpis_disable_button">Enabled</string>
+    <string name="dialog_hyperos_native_warning">HyperOS native/Flutter app detected. Current Java hooks may not load, so DP/font replacement can be ineffective.</string>
+    <string name="dialog_hyperos_native_proxy_present">HyperOS Native Proxy: detected. Rust/Flutter font hook can be used after restarting the target app.</string>
+    <string name="dialog_hyperos_native_proxy_missing">HyperOS Native Proxy: not detected in the target app native directory, so Rust/Flutter font hook may not take effect.</string>
+    <string name="dialog_hyperos_native_proxy_unknown">HyperOS Native Proxy: unable to check the target app native directory. If font hook does not work, verify libdpis_native.so manually.</string>
+    <string name="module_runtime_reload_title">System-level hooks may need reload</string>
+    <string name="module_runtime_reload_message">DPIS was updated after this boot. Normal Java app hooks may work after restarting the target app, but system_server/HyperOS Rust hooks can still be running the previous module code. If Gallery or other HyperOS apps do not change, reboot the device or restart the module runtime/system_server before testing.</string>
+    <string name="module_runtime_reload_ack_button">Got it</string>
     <string name="dialog_process_requires_root">Root access required</string>
     <string name="dialog_process_restart_requires_root">Root access required to restart</string>
     <string name="dialog_process_stop_requires_root">Root access required to stop</string>
@@ -107,6 +114,8 @@
     <string name="font_debug_reason_not_injected_hint">Module not loaded. Check LSPosed and restart the app.</string>
     <string name="font_debug_reason_no_events">No events</string>
     <string name="font_debug_reason_no_events_hint">Injected, but no font paths hit. Open a text page or view totals.</string>
+    <string name="settings_hyperos_flutter_font_hook_label">Experimental HyperOS Flutter font hook</string>
+    <string name="settings_hyperos_flutter_font_hook_hint">Native text hook for HyperOS Flutter apps. Requires app restart.</string>
     <string name="settings_about_label">About</string>
     <string name="settings_about_hint">Version, source code, and feedback.</string>
     <string name="settings_config_backup_label">Config backup</string>

--- a/app/src/main/res/values/strings.xml
+++ b/app/src/main/res/values/strings.xml
@@ -53,7 +53,11 @@
     <string name="dialog_hyperos_native_proxy_unmount_success">HyperOS compatibility support rolled back. Restart the target app.</string>
     <string name="dialog_hyperos_native_proxy_unmount_failed">HyperOS compatibility rollback failed. Check root access and try again.</string>
     <string name="module_runtime_reload_title">System-level hooks may need reload</string>
-    <string name="module_runtime_reload_message">DPIS was updated after this boot. Normal Java app hooks may work after restarting the target app, but system_server/HyperOS Rust hooks can still be running the previous module code. If Gallery or other HyperOS apps do not change, reboot the device or restart the module runtime/system_server before testing.</string>
+    <string name="module_runtime_reload_message">DPIS was updated after this boot. Normal Java app hooks may work after restarting the target app, but system_server/HyperOS Rust hooks can still be running the previous module code. To apply the new HyperOS compatibility code without a full device reboot, reload the module runtime now. This will briefly restart Android system services.</string>
+    <string name="module_runtime_reload_now_button">Reload now</string>
+    <string name="module_runtime_reload_later_button">Later</string>
+    <string name="module_runtime_reload_started">Reloading Android runtime…</string>
+    <string name="module_runtime_reload_failed">Runtime reload failed. Check root access or reboot the device.</string>
     <string name="module_runtime_reload_ack_button">Got it</string>
     <string name="dialog_process_requires_root">Root access required</string>
     <string name="dialog_process_restart_requires_root">Root access required to restart</string>

--- a/app/src/main/res/values/styles.xml
+++ b/app/src/main/res/values/styles.xml
@@ -7,6 +7,13 @@
         <item name="android:windowLightStatusBar">true</item>
     </style>
 
+    <style name="Theme.Dpis.Ingest" parent="android:style/Theme.Translucent.NoTitleBar">
+        <item name="android:windowNoDisplay">true</item>
+        <item name="android:windowDisablePreview">true</item>
+        <item name="android:windowIsTranslucent">true</item>
+        <item name="android:windowAnimationStyle">@null</item>
+    </style>
+
     <style name="Widget.Dpis.TextInputLayout.OutlinedBox.Compact"
         parent="Widget.Material3.TextInputLayout.OutlinedBox">
         <item name="boxCollapsedPaddingTop">0dp</item>

--- a/app/src/main/resources/META-INF/xposed/native_init.list
+++ b/app/src/main/resources/META-INF/xposed/native_init.list
@@ -1,0 +1,2 @@
+libdpis_native.so
+dpis_native

--- a/app/src/test/java/com/dpis/module/AppConfigDialogBinderSourceSmokeTest.java
+++ b/app/src/test/java/com/dpis/module/AppConfigDialogBinderSourceSmokeTest.java
@@ -28,6 +28,7 @@ public class AppConfigDialogBinderSourceSmokeTest {
         assertTrue(source.contains("views.viewportInputView.setText(\"\")"));
         assertTrue(source.contains("bindViewportModeToggle(views.viewportModeToggle, ViewportApplyMode.FIELD_REWRITE, true)"));
         assertTrue(source.contains("bindFontModeToggle(views.fontModeToggle, FontApplyMode.FIELD_REWRITE, true)"));
+        assertTrue(source.contains("host.saveAppConfig("));
         assertTrue(source.contains("views.saveButton.setOnClickListener"));
         assertTrue(source.contains("host.saveAppConfig("));
         assertTrue(source.contains("showSaveButtonFeedback(views.saveButton)"));
@@ -43,6 +44,35 @@ public class AppConfigDialogBinderSourceSmokeTest {
         assertTrue(source.contains("refreshDialogState(views, state, style, systemHooksEnabled);"));
     }
 
+    @Test
+    public void binderShowsHyperOsNativeProxyStatus() throws IOException {
+        String source = read("src/main/java/com/dpis/module/AppConfigDialogBinder.java");
+        String strings = read("src/main/res/values/strings.xml");
+
+        assertTrue(source.contains("HyperOsNativeProxyStatus.inspect(activity, item.packageName)"));
+        assertTrue(source.contains("dialog_hyperos_native_proxy_present"));
+        assertTrue(source.contains("dialog_hyperos_native_proxy_missing"));
+        assertTrue(source.contains("dialog_hyperos_native_proxy_unknown"));
+        assertTrue(strings.contains("dialog_hyperos_native_proxy_present"));
+        assertTrue(strings.contains("dialog_hyperos_native_proxy_missing"));
+        assertTrue(strings.contains("dialog_hyperos_native_proxy_unknown"));
+    }
+
+    @Test
+    public void savingEmptyFontConfigClearsHyperOsNativeTarget() throws IOException {
+        String source = read("src/main/java/com/dpis/module/AppConfigSaveHandler.java");
+
+        assertTrue(source.contains("HyperOsNativeFontPropertySyncer.clearFontTargetAsync(item.packageName)"));
+    }
+
+    @Test
+    public void savingFontConfigPublishesHyperOsNativeTargetWhenModeEnabled() throws IOException {
+        String source = read("src/main/java/com/dpis/module/AppConfigSaveHandler.java");
+
+        assertTrue(source.contains("FontApplyMode.isEnabled(fontMode)"));
+        assertTrue(source.contains("HyperOsNativeFontPropertySyncer.publishForceFontTargetAsync("));
+        assertTrue(source.contains("item.packageName, fontScalePercent"));
+    }
     private static String read(String relativePath) throws IOException {
         return new String(Files.readAllBytes(Path.of(relativePath)), StandardCharsets.UTF_8);
     }

--- a/app/src/test/java/com/dpis/module/AppConfigDialogBinderSourceSmokeTest.java
+++ b/app/src/test/java/com/dpis/module/AppConfigDialogBinderSourceSmokeTest.java
@@ -1,5 +1,6 @@
 package com.dpis.module;
 
+import static org.junit.Assert.assertFalse;
 import static org.junit.Assert.assertTrue;
 
 import java.io.IOException;
@@ -20,6 +21,9 @@ public class AppConfigDialogBinderSourceSmokeTest {
         assertTrue(source.contains("host.setDpisEnabled(item.packageName, nextEnabled)"));
         assertTrue(source.contains("views.startButton.setOnClickListener"));
         assertTrue(source.contains("ProcessAction.START"));
+        assertTrue(source.contains("syncHyperOsNativeProxyAfterSave(item, views, state)"));
+        assertTrue(source.contains("host.applyHyperOsNativeProxy(item, onFinished)"));
+        assertTrue(source.contains("host.unmountHyperOsNativeProxy(item"));
         assertTrue(source.contains("views.restartButton.setOnClickListener"));
         assertTrue(source.contains("ProcessAction.RESTART"));
         assertTrue(source.contains("views.stopButton.setOnClickListener"));
@@ -54,8 +58,49 @@ public class AppConfigDialogBinderSourceSmokeTest {
         assertTrue(source.contains("dialog_hyperos_native_proxy_missing"));
         assertTrue(source.contains("dialog_hyperos_native_proxy_unknown"));
         assertTrue(strings.contains("dialog_hyperos_native_proxy_present"));
+        assertFalse(strings.contains("native directory"));
+        assertFalse(strings.contains("libdpis_native.so"));
         assertTrue(strings.contains("dialog_hyperos_native_proxy_missing"));
         assertTrue(strings.contains("dialog_hyperos_native_proxy_unknown"));
+        assertTrue(strings.contains("dialog_hyperos_native_proxy_apply_success"));
+        assertTrue(strings.contains("dialog_hyperos_native_proxy_unmount_success"));
+    }
+
+
+
+    @Test
+    public void binderDoesNotKeepEmptyHyperOsSectionWrapper() throws IOException {
+        String source = read("src/main/java/com/dpis/module/AppConfigDialogBinder.java");
+
+        assertFalse(source.contains("bindHyperOsNativeSection"));
+    }
+
+    @Test
+    public void simplifiedChineseHyperOsProxyMessagesAreLocalized() throws IOException {
+        String strings = read("src/main/res/values-zh-rCN/strings.xml");
+
+        assertFalse(strings.contains("HyperOS Native Proxy applied. Restart target app."));
+        assertFalse(strings.contains("HyperOS Native Proxy apply failed. Check root and native directory."));
+        assertTrue(strings.contains("HyperOS &#x517C;&#x5BB9;&#x652F;&#x6301;"));
+        assertTrue(strings.contains("&#x8BBE;&#x7F6E;&#x5931;&#x8D25;"));
+    }
+
+    @Test
+    public void resetButtonOnlyClearsDialogInputsUntilSaved() throws IOException {
+        String source = read("src/main/java/com/dpis/module/AppConfigDialogBinder.java");
+        int resetStart = source.indexOf("views.disableButton.setOnClickListener");
+        int saveStart = source.indexOf("views.saveButton.setOnClickListener");
+        String resetBlock = source.substring(resetStart, saveStart);
+
+        assertFalse(resetBlock.contains("unmountHyperOsNativeProxy"));
+    }
+
+    @Test
+    public void savingViewportConfigPublishesRuntimeViewportTarget() throws IOException {
+        String source = read("src/main/java/com/dpis/module/AppConfigSaveHandler.java");
+
+        assertTrue(source.contains("ViewportPropertySyncer.publishTargetAsync(item.packageName, widthDp)"));
+        assertTrue(source.contains("ViewportPropertySyncer.clearTargetAsync(item.packageName)"));
     }
 
     @Test
@@ -73,6 +118,7 @@ public class AppConfigDialogBinderSourceSmokeTest {
         assertTrue(source.contains("HyperOsNativeFontPropertySyncer.publishForceFontTargetAsync("));
         assertTrue(source.contains("item.packageName, fontScalePercent"));
     }
+
     private static String read(String relativePath) throws IOException {
         return new String(Files.readAllBytes(Path.of(relativePath)), StandardCharsets.UTF_8);
     }

--- a/app/src/test/java/com/dpis/module/AppListVisibleSectionsTest.java
+++ b/app/src/test/java/com/dpis/module/AppListVisibleSectionsTest.java
@@ -19,6 +19,7 @@ public class AppListVisibleSectionsTest {
                 FontApplyMode.OFF,
                 true,
                 false,
+                false,
                 null);
         AppListItem plain = new AppListItem(
                 "Android System WebView",
@@ -30,6 +31,7 @@ public class AppListVisibleSectionsTest {
                 FontApplyMode.OFF,
                 true,
                 true,
+                false,
                 null);
 
         List<AppListItem> configuredItems = AppListVisibleSections.filter(

--- a/app/src/test/java/com/dpis/module/DpisApplicationMigrationTest.java
+++ b/app/src/test/java/com/dpis/module/DpisApplicationMigrationTest.java
@@ -3,8 +3,11 @@ package com.dpis.module;
 import org.junit.Test;
 
 import java.lang.reflect.Method;
+import java.util.LinkedHashSet;
 
 import static org.junit.Assert.assertFalse;
+import static org.junit.Assert.assertEquals;
+import static org.junit.Assert.assertNull;
 import static org.junit.Assert.assertTrue;
 
 public class DpisApplicationMigrationTest {
@@ -155,6 +158,66 @@ public class DpisApplicationMigrationTest {
     }
 
     @Test
+    public void preservesRemoteOnlyPackageConfigDuringMigration() throws Exception {
+        FakePrefs localPrefs = new FakePrefs();
+        DpiConfigStore local = new DpiConfigStore(localPrefs);
+        assertTrue(local.setTargetViewportWidthDp("com.miui.weather2", 500));
+
+        FakePrefs remotePrefs = new FakePrefs();
+        DpiConfigStore remote = new DpiConfigStore(remotePrefs);
+        assertTrue(remote.setTargetViewportWidthDp("com.miui.gallery", 500));
+        assertTrue(remote.setTargetViewportApplyMode(
+                "com.miui.gallery", ViewportApplyMode.FIELD_REWRITE));
+        assertTrue(remote.setTargetFontScalePercent("com.miui.gallery", 300));
+        assertTrue(remote.setTargetFontApplyMode(
+                "com.miui.gallery", FontApplyMode.SYSTEM_EMULATION));
+
+        invokeMigrate(local, remote);
+
+        DpiConfigStore remoteOnly = new DpiConfigStore(remotePrefs);
+        assertTrue(remoteOnly.getConfiguredPackages().contains("com.miui.gallery"));
+        assertTrue(remoteOnly.getTargetViewportWidthDp("com.miui.gallery") == 500);
+        assertTrue(remoteOnly.getTargetFontScalePercent("com.miui.gallery") == 300);
+        assertTrue(FontApplyMode.SYSTEM_EMULATION.equals(
+                remoteOnly.getTargetFontApplyMode("com.miui.gallery")));
+    }
+
+    @Test
+    public void nativeProxyAssetResolverUsesFirstSupportedAvailableAbi() {
+        LinkedHashSet<String> available = new LinkedHashSet<>();
+        available.add("native/armeabi-v7a/libdpis_native.so");
+        available.add("native/arm64-v8a/libdpis_native.so");
+
+        String path = HyperOsNativeProxyAssetExporter.resolveNativeProxyAssetPath(available,
+                new String[]{"x86_64", "arm64-v8a", "armeabi-v7a"});
+
+        assertEquals("native/arm64-v8a/libdpis_native.so", path);
+    }
+
+    @Test
+    public void nativeProxyAssetResolverFallsBackToArm64ThenFirstAvailable() {
+        LinkedHashSet<String> available = new LinkedHashSet<>();
+        available.add("native/armeabi-v7a/libdpis_native.so");
+        available.add("native/arm64-v8a/libdpis_native.so");
+
+        String arm64Path = HyperOsNativeProxyAssetExporter.resolveNativeProxyAssetPath(available,
+                new String[]{"x86_64"});
+        String firstPath = HyperOsNativeProxyAssetExporter.resolveNativeProxyAssetPath(available,
+                new String[]{"x86_64", "x86"});
+
+        assertEquals("native/arm64-v8a/libdpis_native.so", arm64Path);
+        assertEquals("native/arm64-v8a/libdpis_native.so", firstPath);
+    }
+
+    @Test
+    public void nativeProxyAssetResolverReturnsNullWhenNoAssetsAvailable() {
+        assertNull(HyperOsNativeProxyAssetExporter.resolveNativeProxyAssetPath(new LinkedHashSet<>(),
+                new String[]{"arm64-v8a"}));
+        assertNull(HyperOsNativeProxyAssetExporter.resolveNativeProxyAssetPath(null,
+                new String[]{"arm64-v8a"}));
+    }
+
+    @Test
     public void doesNotOverwriteRemoteLauncherIconHiddenWhenLocalMissing() throws Exception {
         FakePrefs localPrefs = new FakePrefs();
         DpiConfigStore local = new DpiConfigStore(localPrefs);
@@ -180,6 +243,20 @@ public class DpisApplicationMigrationTest {
         invokeMigrate(local, remote);
 
         assertTrue(remote.isLauncherIconHidden());
+    }
+
+    @Test
+    public void seedsRemoteHyperOsFlutterFontHookFlagWhenRemoteMissing() throws Exception {
+        FakePrefs localPrefs = new FakePrefs();
+        DpiConfigStore local = new DpiConfigStore(localPrefs);
+        assertTrue(local.setHyperOsFlutterFontHookEnabled(true));
+
+        FakePrefs remotePrefs = new FakePrefs();
+        DpiConfigStore remote = new DpiConfigStore(remotePrefs);
+
+        invokeMigrate(local, remote);
+
+        assertTrue(remote.isHyperOsFlutterFontHookEnabled());
     }
 
     private static void invokeMigrate(DpiConfigStore from, DpiConfigStore to) throws Exception {

--- a/app/src/test/java/com/dpis/module/FontDebugStatsFileBridgeTest.java
+++ b/app/src/test/java/com/dpis/module/FontDebugStatsFileBridgeTest.java
@@ -1,0 +1,61 @@
+package com.dpis.module;
+
+import static org.junit.Assert.assertEquals;
+
+import java.util.Properties;
+
+import org.junit.Test;
+
+public class FontDebugStatsFileBridgeTest {
+    @Test
+    public void importIfNewerIgnoresOlderFileData() {
+        FakePrefs preferences = new FakePrefs();
+        preferences.edit()
+                .putLong(FontDebugStatsStore.KEY_UPDATED_AT, 200L)
+                .putString(FontDebugStatsStore.KEY_CHAIN_5S, "new")
+                .apply();
+        Properties properties = new Properties();
+        properties.setProperty(FontDebugStatsStore.EXTRA_UPDATED_AT, "100");
+        properties.setProperty(FontDebugStatsStore.EXTRA_CHAIN_5S, "old");
+
+        FontDebugStatsFileBridge.importIfNewer(preferences, properties);
+
+        assertEquals(200L, preferences.getLong(FontDebugStatsStore.KEY_UPDATED_AT, 0L));
+        assertEquals("new", preferences.getString(FontDebugStatsStore.KEY_CHAIN_5S, null));
+    }
+
+    @Test
+    public void importIfNewerAppliesNewerFileData() {
+        FakePrefs preferences = new FakePrefs();
+        preferences.edit()
+                .putLong(FontDebugStatsStore.KEY_UPDATED_AT, 100L)
+                .putString(FontDebugStatsStore.KEY_CHAIN_5S, "old")
+                .apply();
+        Properties properties = new Properties();
+        properties.setProperty(FontDebugStatsStore.EXTRA_UPDATED_AT, "200");
+        properties.setProperty(FontDebugStatsStore.EXTRA_CHAIN_5S, "new");
+        properties.setProperty(FontDebugStatsStore.EXTRA_EVENT_TOTAL, "3");
+
+        FontDebugStatsFileBridge.importIfNewer(preferences, properties);
+
+        assertEquals(200L, preferences.getLong(FontDebugStatsStore.KEY_UPDATED_AT, 0L));
+        assertEquals("new", preferences.getString(FontDebugStatsStore.KEY_CHAIN_5S, null));
+        assertEquals(3, preferences.getInt(FontDebugStatsStore.KEY_EVENT_TOTAL, 0));
+    }
+
+    @Test
+    public void importIfNewerIgnoresMissingTimestamp() {
+        FakePrefs preferences = new FakePrefs();
+        preferences.edit()
+                .putLong(FontDebugStatsStore.KEY_UPDATED_AT, 100L)
+                .putString(FontDebugStatsStore.KEY_CHAIN_5S, "current")
+                .apply();
+        Properties properties = new Properties();
+        properties.setProperty(FontDebugStatsStore.EXTRA_CHAIN_5S, "missing timestamp");
+
+        FontDebugStatsFileBridge.importIfNewer(preferences, properties);
+
+        assertEquals(100L, preferences.getLong(FontDebugStatsStore.KEY_UPDATED_AT, 0L));
+        assertEquals("current", preferences.getString(FontDebugStatsStore.KEY_CHAIN_5S, null));
+    }
+}

--- a/app/src/test/java/com/dpis/module/FontDebugStatsProviderSourceSmokeTest.java
+++ b/app/src/test/java/com/dpis/module/FontDebugStatsProviderSourceSmokeTest.java
@@ -1,0 +1,94 @@
+package com.dpis.module;
+
+import static org.junit.Assert.assertTrue;
+
+import java.io.IOException;
+import java.nio.charset.StandardCharsets;
+import java.nio.file.Files;
+import java.nio.file.Path;
+
+import org.junit.Test;
+
+public class FontDebugStatsProviderSourceSmokeTest {
+    @Test
+    public void manifestDeclaresInternalFontDebugStatsFallbacks() throws IOException {
+        String manifest = read("src/main/AndroidManifest.xml");
+
+        assertTrue(manifest.contains("android:name=\".FontDebugStatsProvider\""));
+        assertTrue(manifest.contains("android:authorities=\"${applicationId}.fontdebugstats\""));
+        assertComponentExportedFalse(manifest, ".FontDebugStatsProvider");
+        assertTrue(manifest.contains("android:name=\".FontDebugStatsIngestService\""));
+        assertTrue(manifest.contains("android:name=\".FontDebugStatsIngestActivity\""));
+        assertComponentExportedFalse(manifest, ".FontDebugStatsIngestService");
+        assertComponentExportedFalse(manifest, ".FontDebugStatsIngestActivity");
+        assertComponentExportedFalse(manifest, ".FontDebugStatsReceiver");
+    }
+
+    @Test
+    public void fontStatsReportersUseProviderTransportInsteadOfDirectBroadcasts() throws IOException {
+        String fontReporter = read("src/main/java/com/dpis/module/FontDebugStatsReporter.java");
+        String viewportReporter = read("src/main/java/com/dpis/module/ViewportDebugReporter.java");
+
+        assertTrue(fontReporter.contains("FontDebugStatsTransport.sendUpdate(context, extras)"));
+        assertTrue(viewportReporter.contains("FontDebugStatsTransport.sendUpdate(context, extras)"));
+        assertTrue(!fontReporter.contains("context.sendBroadcast(intent)"));
+        assertTrue(!viewportReporter.contains("context.sendBroadcast(intent)"));
+    }
+
+    @Test
+    public void receiverAndProviderShareSamePreferenceWriter() throws IOException {
+        String receiver = read("src/main/java/com/dpis/module/FontDebugStatsReceiver.java");
+        String provider = read("src/main/java/com/dpis/module/FontDebugStatsProvider.java");
+
+        assertTrue(receiver.contains("FontDebugStatsUpdateWriter.applyExtras("));
+        assertTrue(provider.contains("FontDebugStatsUpdateWriter.applyExtras("));
+    }
+
+    @Test
+    public void transportPrefersXposedRemotePreferencesBeforeProviderFallback() throws IOException {
+        String transport = read("src/main/java/com/dpis/module/FontDebugStatsTransport.java");
+        String moduleMain = read("src/main/java/com/dpis/module/ModuleMain.java");
+
+        assertTrue(transport.contains("xposed.getRemotePreferences(DpiConfigStore.GROUP)"));
+        assertTrue(transport.contains("MODULE_CLASS_PACKAGE + \".FontDebugStatsReceiver\""));
+        assertTrue(transport.contains("MODULE_CLASS_PACKAGE + \".FontDebugStatsIngestService\""));
+        assertTrue(transport.contains("MODULE_CLASS_PACKAGE + \".FontDebugStatsIngestActivity\""));
+        assertTrue(transport.contains("FontDebugStatsUpdateWriter.applyExtras(preferences, extras)"));
+        assertTrue(transport.contains("context.getContentResolver().call(buildUri()"));
+        assertTrue(transport.contains("context.sendBroadcast(intent)"));
+        assertTrue(transport.contains("context.startService(intent)"));
+        assertTrue(transport.contains("context.startActivity(intent)"));
+        assertTrue(transport.contains("FontDebugStatsFileBridge.write(extras)"));
+        assertTrue(!transport.contains("return;\n        } catch (Throwable throwable)"));
+        assertTrue(moduleMain.contains("FontDebugStatsTransport.initialize(this)"));
+    }
+
+    @Test
+    public void overlayImportsFileBridgeBeforeRendering() throws IOException {
+        String overlay = read("src/main/java/com/dpis/module/FontDebugOverlayService.java");
+
+        assertTrue(overlay.contains("HandlerThread"));
+        assertTrue(overlay.contains("scheduleBridgeImportIfNeeded()"));
+        assertTrue(overlay.contains("FontDebugStatsFileBridge.importIfNewer(this)"));
+        assertTrue(overlay.contains("FontDebugLogcatBridge.importRecent(this)"));
+    }
+
+    @Test
+    public void manifestDoesNotRequestReadLogsForLogcatFallback() throws IOException {
+        String manifest = read("src/main/AndroidManifest.xml");
+
+        assertTrue(!manifest.contains("android.permission.READ_LOGS"));
+    }
+
+    private static void assertComponentExportedFalse(String manifest, String componentName) {
+        int nameIndex = manifest.indexOf("android:name=\"" + componentName + "\"");
+        assertTrue("missing component " + componentName, nameIndex >= 0);
+        int exportedIndex = manifest.indexOf("android:exported=\"false\"", nameIndex);
+        assertTrue("component should be non-exported " + componentName,
+                exportedIndex >= 0 && exportedIndex - nameIndex < 200);
+    }
+
+    private static String read(String relativePath) throws IOException {
+        return new String(Files.readAllBytes(Path.of(relativePath)), StandardCharsets.UTF_8);
+    }
+}

--- a/app/src/test/java/com/dpis/module/HyperOsFlutterFontHookConfigTest.java
+++ b/app/src/test/java/com/dpis/module/HyperOsFlutterFontHookConfigTest.java
@@ -29,6 +29,21 @@ public class HyperOsFlutterFontHookConfigTest {
                 HyperOsFlutterFontBridge.forcePropertyNameForPackage("com.miui.gallery"));
     }
 
+
+    @Test
+    public void viewportBridgePropertyNameUsesStablePackageHash() {
+        assertEquals("debug.dpis.vp.a55b5fe1",
+                ViewportPropertyBridge.propertyNameForPackage("com.miui.gallery"));
+    }
+
+    @Test
+    public void viewportBridgeParsesPositiveOverrideAndExplicitClear() {
+        assertEquals(Integer.valueOf(300), ViewportPropertyBridge.parseOverrideValueForTest("300"));
+        assertEquals(Integer.valueOf(0), ViewportPropertyBridge.parseOverrideValueForTest("0"));
+        assertEquals(null, ViewportPropertyBridge.parseOverrideValueForTest(""));
+        assertEquals(null, ViewportPropertyBridge.parseOverrideValueForTest("abc"));
+    }
+
     @Test
     public void rustProcessEnvironmentIncludesFontTarget() {
         String envs = HyperOsRustProcessHookInstaller.appendEnvironmentForTest(
@@ -39,6 +54,14 @@ public class HyperOsFlutterFontHookConfigTest {
                         + " --envs=DPIS_RUST_BINARY=/data/app/MIUIGallery/lib/arm64/libapp_gallery.so"
                         + " --cold-boot-speed",
                 envs);
+    }
+
+    @Test
+    public void rustProcessProxyFallsBackToSiblingPath() {
+        String proxyPath = HyperOsRustProcessHookInstaller.resolveProxyLibraryPathForTest(
+                "/missing/MIUIGallery/lib/arm64/libapp_gallery.so");
+
+        assertEquals(null, proxyPath);
     }
 
     @Test

--- a/app/src/test/java/com/dpis/module/HyperOsFlutterFontHookConfigTest.java
+++ b/app/src/test/java/com/dpis/module/HyperOsFlutterFontHookConfigTest.java
@@ -1,0 +1,56 @@
+package com.dpis.module;
+
+import static org.junit.Assert.assertFalse;
+import static org.junit.Assert.assertEquals;
+import static org.junit.Assert.assertTrue;
+
+import org.junit.Test;
+
+public class HyperOsFlutterFontHookConfigTest {
+    @Test
+    public void experimentalHookDefaultsOffAndPersists() {
+        DpiConfigStore store = new DpiConfigStore(new FakePrefs());
+
+        assertFalse(store.isHyperOsFlutterFontHookEnabled());
+
+        assertTrue(store.setHyperOsFlutterFontHookEnabled(true));
+        assertTrue(store.isHyperOsFlutterFontHookEnabled());
+    }
+
+    @Test
+    public void bridgePropertyNameUsesStablePackageHash() {
+        assertEquals("debug.dpis.font.a55b5fe1",
+                HyperOsFlutterFontBridge.propertyNameForPackage("com.miui.gallery"));
+    }
+
+    @Test
+    public void bridgeForcePropertyNameUsesStablePackageHash() {
+        assertEquals("debug.dpis.forcefont.a55b5fe1",
+                HyperOsFlutterFontBridge.forcePropertyNameForPackage("com.miui.gallery"));
+    }
+
+    @Test
+    public void rustProcessEnvironmentIncludesFontTarget() {
+        String envs = HyperOsRustProcessHookInstaller.appendEnvironmentForTest(
+                "", "com.miui.gallery", 300,
+                "/data/app/MIUIGallery/lib/arm64/libapp_gallery.so");
+
+        assertEquals("DPIS_PACKAGE=com.miui.gallery --envs=DPIS_FONT_SCALE_PERCENT=300"
+                        + " --envs=DPIS_RUST_BINARY=/data/app/MIUIGallery/lib/arm64/libapp_gallery.so"
+                        + " --cold-boot-speed",
+                envs);
+    }
+
+    @Test
+    public void bridgeDoesNotClearRustTargetWhenUiHookSwitchIsOff() throws Exception {
+        java.lang.reflect.Method method = HyperOsFlutterFontBridge.class.getDeclaredMethod(
+                "shouldClearOnPublishTargetSkipForTest", String.class, PerAppDisplayConfig.class);
+        method.setAccessible(true);
+        PerAppDisplayConfig config = new PerAppDisplayConfig("com.miui.gallery", null,
+                300, FontApplyMode.SYSTEM_EMULATION, false);
+
+        boolean shouldClear = (boolean) method.invoke(null, "com.miui.gallery", config);
+
+        assertFalse(shouldClear);
+    }
+}

--- a/app/src/test/java/com/dpis/module/HyperOsFlutterFontHookConfigTest.java
+++ b/app/src/test/java/com/dpis/module/HyperOsFlutterFontHookConfigTest.java
@@ -76,4 +76,97 @@ public class HyperOsFlutterFontHookConfigTest {
 
         assertFalse(shouldClear);
     }
+    @Test
+    public void nativeForceFontPropertyCanOverrideJniConfiguration() throws Exception {
+        java.nio.file.Path nativeSource = java.nio.file.Paths.get("src/main/cpp/dpis_native.cpp");
+        if (!java.nio.file.Files.exists(nativeSource)) {
+            nativeSource = java.nio.file.Paths.get("app/src/main/cpp/dpis_native.cpp");
+        }
+        String source = new String(java.nio.file.Files.readAllBytes(nativeSource),
+                java.nio.charset.StandardCharsets.UTF_8);
+
+        assertFalse(source.contains("if (g_configured_from_jni.load(std::memory_order_relaxed)) {\n        return;"));
+        assertTrue(source.indexOf("debug.dpis.forcefont.%08x")
+                < source.indexOf("DPIS_FONT_SCALE_PERCENT"));
+        assertTrue(source.indexOf("debug.dpis.forcefont")
+                < source.indexOf("debug.dpis.font.%08x"));
+    }
+    @Test
+    public void nativeCreateHookScalesWeatherCreateFontRegisters() throws Exception {
+        java.nio.file.Path nativeSource = java.nio.file.Paths.get("src/main/cpp/dpis_native.cpp");
+        if (!java.nio.file.Files.exists(nativeSource)) {
+            nativeSource = java.nio.file.Paths.get("app/src/main/cpp/dpis_native.cpp");
+        }
+        String source = new String(java.nio.file.Files.readAllBytes(nativeSource),
+                java.nio.charset.StandardCharsets.UTF_8);
+
+        int createScale = source.indexOf("bl dpis_create_scaled_d0");
+        String createTrampoline = source.substring(Math.max(0, createScale - 300), createScale + 180);
+        assertTrue(source.contains("double create_observed_scale(double observed_scale)"));
+        assertTrue(source.contains("return 1.0;"));
+        assertTrue(createTrampoline.contains("ldr d0, [sp, #80]"));
+        assertTrue(createTrampoline.contains("bl dpis_create_scaled_d0"));
+        assertTrue(createTrampoline.contains("fmul d0, d0, d1"));
+    }
+
+    @Test
+    public void nativeProxyLoadsOriginalRustBinaryFromEnvironmentBeforeProperty() throws Exception {
+        java.nio.file.Path nativeSource = java.nio.file.Paths.get("src/main/cpp/dpis_native.cpp");
+        if (!java.nio.file.Files.exists(nativeSource)) {
+            nativeSource = java.nio.file.Paths.get("app/src/main/cpp/dpis_native.cpp");
+        }
+        String source = new String(java.nio.file.Files.readAllBytes(nativeSource),
+                java.nio.charset.StandardCharsets.UTF_8);
+
+        int envRead = source.indexOf("read_environment(\"DPIS_RUST_BINARY\")");
+        int propertyRead = source.indexOf("debug.dpis.rustbin.%08x");
+        assertTrue(envRead >= 0);
+        assertTrue(propertyRead >= 0);
+        assertTrue(envRead < propertyRead);
+    }
+
+    @Test
+    public void weatherNativeProxyFallsBackToSiblingOriginalLibrary() throws Exception {
+        java.nio.file.Path nativeSource = java.nio.file.Paths.get("src/main/cpp/dpis_native.cpp");
+        if (!java.nio.file.Files.exists(nativeSource)) {
+            nativeSource = java.nio.file.Paths.get("app/src/main/cpp/dpis_native.cpp");
+        }
+        String source = new String(java.nio.file.Files.readAllBytes(nativeSource),
+                java.nio.charset.StandardCharsets.UTF_8);
+
+        assertTrue(source.contains("sibling_original_rust_binary_path()"));
+        assertTrue(source.contains("current_process_name() != \"com.miui.weather2\""));
+        assertTrue(source.contains("libweather_app.so"));
+        assertTrue(source.contains("path == \"0\""));
+    }
+
+    @Test
+    public void weatherGotHookValidatesOriginalSlotBeforePatching() throws Exception {
+        java.nio.file.Path nativeSource = java.nio.file.Paths.get("src/main/cpp/dpis_native.cpp");
+        if (!java.nio.file.Files.exists(nativeSource)) {
+            nativeSource = java.nio.file.Paths.get("app/src/main/cpp/dpis_native.cpp");
+        }
+        String source = new String(java.nio.file.Files.readAllBytes(nativeSource),
+                java.nio.charset.StandardCharsets.UTF_8);
+
+        assertTrue(source.contains("is_weather_configuration_font_scale_slot"));
+        assertTrue(source.contains("GOT hook skipped: unexpected slot"));
+        assertTrue(source.indexOf("is_weather_configuration_font_scale_slot(*slot)")
+                < source.indexOf("*slot = reinterpret_cast<void *>(Configuration_get_font_scale)"));
+    }
+
+    @Test
+    public void rustProcessProxyRejectsEmptySiblingPlaceholder() throws Exception {
+        java.io.File dir = java.nio.file.Files.createTempDirectory("dpis-rust-proxy").toFile();
+        java.io.File original = new java.io.File(dir, "libweather_app.so");
+        java.io.File proxy = new java.io.File(dir, "libdpis_native.so");
+        assertTrue(original.createNewFile());
+        assertTrue(proxy.createNewFile());
+
+        String proxyPath = HyperOsRustProcessHookInstaller.resolveProxyLibraryPathForTest(
+                original.getAbsolutePath());
+
+        assertEquals(null, proxyPath);
+    }
+
 }

--- a/app/src/test/java/com/dpis/module/HyperOsFlutterFontHookConfigTest.java
+++ b/app/src/test/java/com/dpis/module/HyperOsFlutterFontHookConfigTest.java
@@ -76,14 +76,18 @@ public class HyperOsFlutterFontHookConfigTest {
 
         assertFalse(shouldClear);
     }
+
+    @Test
+    public void nativeHookInstallerRequiresEnabledFontMode() throws Exception {
+        String source = readSource("src/main/java/com/dpis/module/HyperOsFlutterFontHookInstaller.java");
+
+        assertTrue(source.contains("store.getTargetFontApplyMode(packageName)"));
+        assertTrue(source.contains("FontApplyMode.isEnabled("));
+    }
+
     @Test
     public void nativeForceFontPropertyCanOverrideJniConfiguration() throws Exception {
-        java.nio.file.Path nativeSource = java.nio.file.Paths.get("src/main/cpp/dpis_native.cpp");
-        if (!java.nio.file.Files.exists(nativeSource)) {
-            nativeSource = java.nio.file.Paths.get("app/src/main/cpp/dpis_native.cpp");
-        }
-        String source = new String(java.nio.file.Files.readAllBytes(nativeSource),
-                java.nio.charset.StandardCharsets.UTF_8);
+        String source = readSource("src/main/cpp/dpis_native.cpp");
 
         assertFalse(source.contains("if (g_configured_from_jni.load(std::memory_order_relaxed)) {\n        return;"));
         assertTrue(source.indexOf("debug.dpis.forcefont.%08x")
@@ -93,12 +97,7 @@ public class HyperOsFlutterFontHookConfigTest {
     }
     @Test
     public void nativeCreateHookScalesWeatherCreateFontRegisters() throws Exception {
-        java.nio.file.Path nativeSource = java.nio.file.Paths.get("src/main/cpp/dpis_native.cpp");
-        if (!java.nio.file.Files.exists(nativeSource)) {
-            nativeSource = java.nio.file.Paths.get("app/src/main/cpp/dpis_native.cpp");
-        }
-        String source = new String(java.nio.file.Files.readAllBytes(nativeSource),
-                java.nio.charset.StandardCharsets.UTF_8);
+        String source = readSource("src/main/cpp/dpis_native.cpp");
 
         int createScale = source.indexOf("bl dpis_create_scaled_d0");
         String createTrampoline = source.substring(Math.max(0, createScale - 300), createScale + 180);
@@ -111,12 +110,7 @@ public class HyperOsFlutterFontHookConfigTest {
 
     @Test
     public void nativeProxyLoadsOriginalRustBinaryFromEnvironmentBeforeProperty() throws Exception {
-        java.nio.file.Path nativeSource = java.nio.file.Paths.get("src/main/cpp/dpis_native.cpp");
-        if (!java.nio.file.Files.exists(nativeSource)) {
-            nativeSource = java.nio.file.Paths.get("app/src/main/cpp/dpis_native.cpp");
-        }
-        String source = new String(java.nio.file.Files.readAllBytes(nativeSource),
-                java.nio.charset.StandardCharsets.UTF_8);
+        String source = readSource("src/main/cpp/dpis_native.cpp");
 
         int envRead = source.indexOf("read_environment(\"DPIS_RUST_BINARY\")");
         int propertyRead = source.indexOf("debug.dpis.rustbin.%08x");
@@ -127,12 +121,7 @@ public class HyperOsFlutterFontHookConfigTest {
 
     @Test
     public void weatherNativeProxyFallsBackToSiblingOriginalLibrary() throws Exception {
-        java.nio.file.Path nativeSource = java.nio.file.Paths.get("src/main/cpp/dpis_native.cpp");
-        if (!java.nio.file.Files.exists(nativeSource)) {
-            nativeSource = java.nio.file.Paths.get("app/src/main/cpp/dpis_native.cpp");
-        }
-        String source = new String(java.nio.file.Files.readAllBytes(nativeSource),
-                java.nio.charset.StandardCharsets.UTF_8);
+        String source = readSource("src/main/cpp/dpis_native.cpp");
 
         assertTrue(source.contains("sibling_original_rust_binary_path()"));
         assertTrue(source.contains("current_process_name() != \"com.miui.weather2\""));
@@ -142,12 +131,7 @@ public class HyperOsFlutterFontHookConfigTest {
 
     @Test
     public void weatherGotHookValidatesOriginalSlotBeforePatching() throws Exception {
-        java.nio.file.Path nativeSource = java.nio.file.Paths.get("src/main/cpp/dpis_native.cpp");
-        if (!java.nio.file.Files.exists(nativeSource)) {
-            nativeSource = java.nio.file.Paths.get("app/src/main/cpp/dpis_native.cpp");
-        }
-        String source = new String(java.nio.file.Files.readAllBytes(nativeSource),
-                java.nio.charset.StandardCharsets.UTF_8);
+        String source = readSource("src/main/cpp/dpis_native.cpp");
 
         assertTrue(source.contains("is_weather_configuration_font_scale_slot"));
         assertTrue(source.contains("GOT hook skipped: unexpected slot"));
@@ -169,4 +153,12 @@ public class HyperOsFlutterFontHookConfigTest {
         assertEquals(null, proxyPath);
     }
 
+    private static String readSource(String relativePath) throws Exception {
+        java.nio.file.Path path = java.nio.file.Paths.get(relativePath);
+        if (!java.nio.file.Files.exists(path)) {
+            path = java.nio.file.Paths.get("app", relativePath);
+        }
+        return new String(java.nio.file.Files.readAllBytes(path),
+                java.nio.charset.StandardCharsets.UTF_8);
+    }
 }

--- a/app/src/test/java/com/dpis/module/HyperOsNativeFontPropertySyncerTest.java
+++ b/app/src/test/java/com/dpis/module/HyperOsNativeFontPropertySyncerTest.java
@@ -1,0 +1,21 @@
+package com.dpis.module;
+
+import static org.junit.Assert.assertEquals;
+
+import org.junit.Test;
+
+public class HyperOsNativeFontPropertySyncerTest {
+    @Test
+    public void shellQuoteEscapesSingleQuotes() {
+        assertEquals("'debug.dpis.forcefont.a55b5fe1'",
+                HyperOsNativeFontPropertySyncer.shellQuoteForTest("debug.dpis.forcefont.a55b5fe1"));
+        assertEquals("'a'\\''b'", HyperOsNativeFontPropertySyncer.shellQuoteForTest("a'b"));
+        assertEquals("''", HyperOsNativeFontPropertySyncer.shellQuoteForTest(""));
+    }
+    @Test
+    public void buildPublishCommandSetsForceFontPropertyOnly() {
+        assertEquals("setprop 'debug.dpis.forcefont.a55b5fe1' '300'",
+                HyperOsNativeFontPropertySyncer.buildPublishCommandForTest(
+                        "debug.dpis.forcefont.a55b5fe1", 300));
+    }
+}

--- a/app/src/test/java/com/dpis/module/HyperOsNativeProxyBindMounterTest.java
+++ b/app/src/test/java/com/dpis/module/HyperOsNativeProxyBindMounterTest.java
@@ -1,0 +1,67 @@
+package com.dpis.module;
+
+import static org.junit.Assert.assertEquals;
+import static org.junit.Assert.assertFalse;
+import static org.junit.Assert.assertTrue;
+
+import java.io.File;
+import java.nio.file.Files;
+
+import org.junit.Test;
+
+public class HyperOsNativeProxyBindMounterTest {
+    @Test
+    public void createPlanRequiresBothProxyFiles() throws Exception {
+        File moduleDir = Files.createTempDirectory("dpis-module-native").toFile();
+        File targetDir = Files.createTempDirectory("dpis-target-native").toFile();
+        assertTrue(new File(moduleDir, "libdpis_native.so").createNewFile());
+
+        HyperOsNativeProxyBindMounter.MountPlan missingTarget =
+                HyperOsNativeProxyBindMounter.createPlan(
+                        moduleDir.getAbsolutePath(), targetDir.getAbsolutePath());
+
+        assertFalse(missingTarget.valid);
+
+        assertTrue(new File(targetDir, "libdpis_native.so").createNewFile());
+        HyperOsNativeProxyBindMounter.MountPlan valid =
+                HyperOsNativeProxyBindMounter.createPlan(
+                        moduleDir.getAbsolutePath(), targetDir.getAbsolutePath());
+
+        assertTrue(valid.valid);
+        assertEquals(new File(moduleDir, "libdpis_native.so").getAbsolutePath(), valid.sourcePath);
+        assertEquals(new File(targetDir, "libdpis_native.so").getAbsolutePath(), valid.targetPath);
+    }
+
+    @Test
+    public void applyCommandBindMountsAndVerifiesHash() {
+        String command = HyperOsNativeProxyBindMounter.buildApplyCommand(
+                "/data/app/module/lib/arm64/libdpis_native.so",
+                "/data/app/MIUIGallery/lib/arm64/libdpis_native.so");
+
+        assertTrue(command.contains("umount -l '/data/app/MIUIGallery/lib/arm64/libdpis_native.so'"));
+        assertTrue(command.contains("&& mount -o bind '/data/app/module/lib/arm64/libdpis_native.so'"
+                + " '/data/app/MIUIGallery/lib/arm64/libdpis_native.so'"));
+        assertTrue(command.contains("&& mount | grep -F -- '/data/app/MIUIGallery/lib/arm64/libdpis_native.so'"));
+        assertTrue(command.contains("&& md5sum '/data/app/module/lib/arm64/libdpis_native.so'"
+                + " '/data/app/MIUIGallery/lib/arm64/libdpis_native.so'"));
+    }
+
+    @Test
+    public void unmountCommandFailsWhenMountStillExists() {
+        String command = HyperOsNativeProxyBindMounter.buildUnmountCommand(
+                "/data/app/MIUIGallery/lib/arm64/libdpis_native.so");
+
+        assertTrue(command.contains("umount -l '/data/app/MIUIGallery/lib/arm64/libdpis_native.so'"));
+        assertTrue(command.contains("mount | grep -F -- '/data/app/MIUIGallery/lib/arm64/libdpis_native.so'"));
+        assertTrue(command.contains("&& exit 1 || exit 0"));
+    }
+
+    @Test
+    public void applyCommandQuotesSingleQuotes() {
+        String command = HyperOsNativeProxyBindMounter.buildApplyCommand(
+                "/data/app/module's/libdpis_native.so",
+                "/data/app/target/libdpis_native.so");
+
+        assertTrue(command.contains("'/data/app/module'\''s/libdpis_native.so'"));
+    }
+}

--- a/app/src/test/java/com/dpis/module/HyperOsNativeProxyBindMounterTest.java
+++ b/app/src/test/java/com/dpis/module/HyperOsNativeProxyBindMounterTest.java
@@ -11,18 +11,11 @@ import org.junit.Test;
 
 public class HyperOsNativeProxyBindMounterTest {
     @Test
-    public void createPlanRequiresBothProxyFiles() throws Exception {
+    public void createPlanAllowsMissingTargetMountPointWhenParentExists() throws Exception {
         File moduleDir = Files.createTempDirectory("dpis-module-native").toFile();
         File targetDir = Files.createTempDirectory("dpis-target-native").toFile();
         assertTrue(new File(moduleDir, "libdpis_native.so").createNewFile());
 
-        HyperOsNativeProxyBindMounter.MountPlan missingTarget =
-                HyperOsNativeProxyBindMounter.createPlan(
-                        moduleDir.getAbsolutePath(), targetDir.getAbsolutePath());
-
-        assertFalse(missingTarget.valid);
-
-        assertTrue(new File(targetDir, "libdpis_native.so").createNewFile());
         HyperOsNativeProxyBindMounter.MountPlan valid =
                 HyperOsNativeProxyBindMounter.createPlan(
                         moduleDir.getAbsolutePath(), targetDir.getAbsolutePath());
@@ -33,27 +26,50 @@ public class HyperOsNativeProxyBindMounterTest {
     }
 
     @Test
-    public void applyCommandBindMountsAndVerifiesHash() {
+    public void createPlanRejectsMissingTargetParentDirectory() throws Exception {
+        File moduleDir = Files.createTempDirectory("dpis-module-native").toFile();
+        File targetParent = new File(Files.createTempDirectory("dpis-target-parent").toFile(), "missing");
+        assertTrue(new File(moduleDir, "libdpis_native.so").createNewFile());
+
+        HyperOsNativeProxyBindMounter.MountPlan plan =
+                HyperOsNativeProxyBindMounter.createPlan(
+                        moduleDir.getAbsolutePath(), targetParent.getAbsolutePath());
+
+        assertFalse(plan.valid);
+        assertTrue(plan.reason.contains("target native library directory missing"));
+    }
+
+    @Test
+    public void applyCommandCopiesProxyAndPrintsHashes() {
         String command = HyperOsNativeProxyBindMounter.buildApplyCommand(
                 "/data/app/module/lib/arm64/libdpis_native.so",
                 "/data/app/MIUIGallery/lib/arm64/libdpis_native.so");
 
         assertTrue(command.contains("umount -l '/data/app/MIUIGallery/lib/arm64/libdpis_native.so'"));
-        assertTrue(command.contains("&& mount -o bind '/data/app/module/lib/arm64/libdpis_native.so'"
+        assertTrue(command.contains("test ! -s '/data/app/MIUIGallery/lib/arm64/libdpis_native.so'"
+                + " || cmp -s '/data/app/module/lib/arm64/libdpis_native.so'"
                 + " '/data/app/MIUIGallery/lib/arm64/libdpis_native.so'"));
-        assertTrue(command.contains("&& mount | grep -F -- '/data/app/MIUIGallery/lib/arm64/libdpis_native.so'"));
-        assertTrue(command.contains("&& md5sum '/data/app/module/lib/arm64/libdpis_native.so'"
+        assertTrue(command.contains("cp -f '/data/app/module/lib/arm64/libdpis_native.so'"
                 + " '/data/app/MIUIGallery/lib/arm64/libdpis_native.so'"));
+        assertTrue(command.contains("cat '/data/app/module/lib/arm64/libdpis_native.so'"
+                + " > '/data/app/MIUIGallery/lib/arm64/libdpis_native.so'"));
+        assertTrue(command.contains("chmod 755 '/data/app/MIUIGallery/lib/arm64/libdpis_native.so'"));
+        assertTrue(command.contains("md5sum '/data/app/module/lib/arm64/libdpis_native.so'"
+                + " '/data/app/MIUIGallery/lib/arm64/libdpis_native.so'"));
+        assertFalse(command.contains("mount -o bind"));
     }
 
     @Test
-    public void unmountCommandFailsWhenMountStillExists() {
+    public void unmountCommandRemovesCopiedProxy() {
         String command = HyperOsNativeProxyBindMounter.buildUnmountCommand(
+                "/data/app/module/lib/arm64/libdpis_native.so",
                 "/data/app/MIUIGallery/lib/arm64/libdpis_native.so");
 
         assertTrue(command.contains("umount -l '/data/app/MIUIGallery/lib/arm64/libdpis_native.so'"));
-        assertTrue(command.contains("mount | grep -F -- '/data/app/MIUIGallery/lib/arm64/libdpis_native.so'"));
-        assertTrue(command.contains("&& exit 1 || exit 0"));
+        assertTrue(command.contains("cmp -s '/data/app/module/lib/arm64/libdpis_native.so'"
+                + " '/data/app/MIUIGallery/lib/arm64/libdpis_native.so'"));
+        assertTrue(command.contains("rm -f '/data/app/MIUIGallery/lib/arm64/libdpis_native.so'"));
+        assertTrue(command.contains("test ! -e '/data/app/MIUIGallery/lib/arm64/libdpis_native.so'"));
     }
 
     @Test

--- a/app/src/test/java/com/dpis/module/HyperOsNativeProxyBindMounterTest.java
+++ b/app/src/test/java/com/dpis/module/HyperOsNativeProxyBindMounterTest.java
@@ -46,17 +46,31 @@ public class HyperOsNativeProxyBindMounterTest {
                 "/data/app/MIUIGallery/lib/arm64/libdpis_native.so");
 
         assertTrue(command.contains("umount -l '/data/app/MIUIGallery/lib/arm64/libdpis_native.so'"));
-        assertTrue(command.contains("test ! -s '/data/app/MIUIGallery/lib/arm64/libdpis_native.so'"
-                + " || cmp -s '/data/app/module/lib/arm64/libdpis_native.so'"
-                + " '/data/app/MIUIGallery/lib/arm64/libdpis_native.so'"));
         assertTrue(command.contains("cp -f '/data/app/module/lib/arm64/libdpis_native.so'"
                 + " '/data/app/MIUIGallery/lib/arm64/libdpis_native.so'"));
         assertTrue(command.contains("cat '/data/app/module/lib/arm64/libdpis_native.so'"
                 + " > '/data/app/MIUIGallery/lib/arm64/libdpis_native.so'"));
         assertTrue(command.contains("chmod 755 '/data/app/MIUIGallery/lib/arm64/libdpis_native.so'"));
+        assertTrue(command.contains("cmp -s '/data/app/module/lib/arm64/libdpis_native.so'"
+                + " '/data/app/MIUIGallery/lib/arm64/libdpis_native.so'"
+                + " || exit 1"));
         assertTrue(command.contains("md5sum '/data/app/module/lib/arm64/libdpis_native.so'"
                 + " '/data/app/MIUIGallery/lib/arm64/libdpis_native.so'"));
+        assertFalse(command.contains("md5sum '/data/app/module/lib/arm64/libdpis_native.so'"
+                + " '/data/app/MIUIGallery/lib/arm64/libdpis_native.so' || exit 1"));
         assertFalse(command.contains("mount -o bind"));
+    }
+
+    @Test
+    public void applyCommandOverwritesExistingProxyCopy() {
+        String command = HyperOsNativeProxyBindMounter.buildApplyCommand(
+                "/data/app/module/lib/arm64/libdpis_native.so",
+                "/data/app/MIUIWeather/lib/arm64/libdpis_native.so");
+
+        assertTrue(command.contains("cp -f '/data/app/module/lib/arm64/libdpis_native.so'"
+                + " '/data/app/MIUIWeather/lib/arm64/libdpis_native.so'"));
+        assertTrue(command.indexOf("cp -f '/data/app/module/lib/arm64/libdpis_native.so'")
+                < command.indexOf("cmp -s '/data/app/module/lib/arm64/libdpis_native.so'"));
     }
 
     @Test
@@ -70,6 +84,22 @@ public class HyperOsNativeProxyBindMounterTest {
                 + " '/data/app/MIUIGallery/lib/arm64/libdpis_native.so'"));
         assertTrue(command.contains("rm -f '/data/app/MIUIGallery/lib/arm64/libdpis_native.so'"));
         assertTrue(command.contains("test ! -e '/data/app/MIUIGallery/lib/arm64/libdpis_native.so'"));
+    }
+
+    @Test
+    public void unmountCommandVerifiesProxyBeforeRemovingTarget() {
+        String command = HyperOsNativeProxyBindMounter.buildUnmountCommand(
+                "/data/app/module/lib/arm64/libdpis_native.so",
+                "/data/app/MIUIWeather/lib/arm64/libdpis_native.so");
+
+        int compareIndex = command.indexOf("cmp -s '/data/app/module/lib/arm64/libdpis_native.so'"
+                + " '/data/app/MIUIWeather/lib/arm64/libdpis_native.so'"
+                + " || exit 1");
+        int removeIndex = command.indexOf("rm -f '/data/app/MIUIWeather/lib/arm64/libdpis_native.so'");
+
+        assertTrue(compareIndex >= 0);
+        assertTrue(removeIndex >= 0);
+        assertTrue(compareIndex < removeIndex);
     }
 
     @Test

--- a/app/src/test/java/com/dpis/module/HyperOsNativeProxyRefreshCoordinatorTest.java
+++ b/app/src/test/java/com/dpis/module/HyperOsNativeProxyRefreshCoordinatorTest.java
@@ -1,0 +1,58 @@
+package com.dpis.module;
+
+import static org.junit.Assert.assertFalse;
+import static org.junit.Assert.assertTrue;
+
+import java.nio.charset.StandardCharsets;
+import java.nio.file.Files;
+import java.nio.file.Path;
+import java.util.LinkedHashSet;
+
+import org.junit.Test;
+
+public class HyperOsNativeProxyRefreshCoordinatorTest {
+    @Test
+    public void coordinatorDocumentsDormantAutomaticRefreshState() throws Exception {
+        String source = read("src/main/java/com/dpis/module/HyperOsNativeProxyRefreshCoordinator.java");
+
+        assertTrue(source.contains("Dormant helper"));
+        assertTrue(source.contains("automatic startup/package-update proxy refresh is intentionally disabled"));
+        assertTrue(source.contains("do not wire it"));
+    }
+
+    @Test
+    public void refreshesOnlyEnabledConfiguredFontTargetsWhenHookEnabled() {
+        DpiConfigStore store = new DpiConfigStore(new FakePrefs());
+        assertTrue(store.setHyperOsFlutterFontHookEnabled(true));
+        assertTrue(store.setTargetFontScalePercent("com.miui.gallery", 180));
+        assertTrue(store.setTargetFontApplyMode("com.miui.gallery", FontApplyMode.SYSTEM_EMULATION));
+        assertTrue(store.setTargetFontScalePercent("com.miui.weather2", 200));
+        assertTrue(store.setTargetFontApplyMode("com.miui.weather2", FontApplyMode.FIELD_REWRITE));
+        assertTrue(store.setTargetViewportWidthDp("com.example.viewport", 500));
+        assertTrue(store.setTargetFontScalePercent("com.example.disabled", 160));
+        assertTrue(store.setTargetFontApplyMode("com.example.disabled", FontApplyMode.FIELD_REWRITE));
+        assertTrue(store.setTargetDpisEnabled("com.example.disabled", false));
+
+        LinkedHashSet<String> packages = HyperOsNativeProxyRefreshCoordinator
+                .collectRefreshPackagesForTest(store);
+
+        assertTrue(packages.contains("com.miui.gallery"));
+        assertTrue(packages.contains("com.miui.weather2"));
+        assertFalse(packages.contains("com.example.viewport"));
+        assertFalse(packages.contains("com.example.disabled"));
+    }
+
+    @Test
+    public void refreshSkipsWhenHookDisabled() {
+        DpiConfigStore store = new DpiConfigStore(new FakePrefs());
+        assertTrue(store.setTargetFontScalePercent("com.miui.gallery", 180));
+        assertTrue(store.setTargetFontApplyMode("com.miui.gallery", FontApplyMode.SYSTEM_EMULATION));
+
+        assertTrue(HyperOsNativeProxyRefreshCoordinator
+                .collectRefreshPackagesForTest(store).isEmpty());
+    }
+
+    private static String read(String relativePath) throws Exception {
+        return new String(Files.readAllBytes(Path.of(relativePath)), StandardCharsets.UTF_8);
+    }
+}

--- a/app/src/test/java/com/dpis/module/HyperOsNativeProxyStatusTest.java
+++ b/app/src/test/java/com/dpis/module/HyperOsNativeProxyStatusTest.java
@@ -1,0 +1,46 @@
+package com.dpis.module;
+
+import static org.junit.Assert.assertEquals;
+import static org.junit.Assert.assertFalse;
+import static org.junit.Assert.assertTrue;
+
+import java.io.File;
+import java.nio.file.Files;
+
+import org.junit.Test;
+
+public class HyperOsNativeProxyStatusTest {
+    @Test
+    public void inspectNativeLibraryDirDetectsProxyLibrary() throws Exception {
+        File nativeDir = Files.createTempDirectory("dpis-native-proxy").toFile();
+        File proxy = new File(nativeDir, "libdpis_native.so");
+        assertTrue(proxy.createNewFile());
+
+        HyperOsNativeProxyStatus status = HyperOsNativeProxyStatus.inspectNativeLibraryDir(
+                nativeDir.getAbsolutePath());
+
+        assertEquals(HyperOsNativeProxyStatus.State.PRESENT, status.state);
+        assertTrue(status.isPresent());
+    }
+
+    @Test
+    public void inspectNativeLibraryDirReportsMissingWhenDirectoryExistsWithoutProxy() throws Exception {
+        File nativeDir = Files.createTempDirectory("dpis-native-proxy-missing").toFile();
+
+        HyperOsNativeProxyStatus status = HyperOsNativeProxyStatus.inspectNativeLibraryDir(
+                nativeDir.getAbsolutePath());
+
+        assertEquals(HyperOsNativeProxyStatus.State.MISSING, status.state);
+        assertFalse(status.isPresent());
+    }
+
+    @Test
+    public void inspectNativeLibraryDirReportsUnknownForBlankOrAbsentDirectory() {
+        HyperOsNativeProxyStatus blank = HyperOsNativeProxyStatus.inspectNativeLibraryDir("");
+        HyperOsNativeProxyStatus absent = HyperOsNativeProxyStatus.inspectNativeLibraryDir(
+                new File("build/nonexistent-dpis-native-proxy-dir").getAbsolutePath());
+
+        assertEquals(HyperOsNativeProxyStatus.State.UNKNOWN, blank.state);
+        assertEquals(HyperOsNativeProxyStatus.State.UNKNOWN, absent.state);
+    }
+}

--- a/app/src/test/java/com/dpis/module/HyperOsNativeProxyStatusTest.java
+++ b/app/src/test/java/com/dpis/module/HyperOsNativeProxyStatusTest.java
@@ -14,13 +14,27 @@ public class HyperOsNativeProxyStatusTest {
     public void inspectNativeLibraryDirDetectsProxyLibrary() throws Exception {
         File nativeDir = Files.createTempDirectory("dpis-native-proxy").toFile();
         File proxy = new File(nativeDir, "libdpis_native.so");
-        assertTrue(proxy.createNewFile());
+        Files.write(proxy.toPath(), new byte[] {1});
 
         HyperOsNativeProxyStatus status = HyperOsNativeProxyStatus.inspectNativeLibraryDir(
                 nativeDir.getAbsolutePath());
 
         assertEquals(HyperOsNativeProxyStatus.State.PRESENT, status.state);
         assertTrue(status.isPresent());
+    }
+
+
+    @Test
+    public void inspectNativeLibraryDirTreatsEmptyPlaceholderAsMissing() throws Exception {
+        File nativeDir = Files.createTempDirectory("dpis-native-proxy-empty").toFile();
+        File proxy = new File(nativeDir, "libdpis_native.so");
+        assertTrue(proxy.createNewFile());
+
+        HyperOsNativeProxyStatus status = HyperOsNativeProxyStatus.inspectNativeLibraryDir(
+                nativeDir.getAbsolutePath());
+
+        assertEquals(HyperOsNativeProxyStatus.State.MISSING, status.state);
+        assertFalse(status.isPresent());
     }
 
     @Test

--- a/app/src/test/java/com/dpis/module/MainActivitySourceSmokeTest.java
+++ b/app/src/test/java/com/dpis/module/MainActivitySourceSmokeTest.java
@@ -88,6 +88,9 @@ public class MainActivitySourceSmokeTest {
     public void startupDisclaimerUsesMaterialDialogAndPersistsConsent() throws IOException {
         String source = read("src/main/java/com/dpis/module/MainActivity.java");
 
+        assertTrue(source.contains("maybeShowModuleRuntimeReloadAdvice()"));
+        assertTrue(source.contains("ModuleRuntimeReloadAdvisor.shouldShowReloadAdvice(this)"));
+        assertTrue(source.contains("ModuleRuntimeReloadAdvisor.markReloadAdviceAcknowledged(this)"));
         assertTrue(source.contains("maybeShowStartupDisclaimerDialog()"));
         assertTrue(source.contains("if (!maybeShowStartupDisclaimerDialog()) {"));
         assertTrue(source.contains("startupUpdateDialogCoordinator().maybeShowStartupDisclaimerDialog("));
@@ -230,6 +233,7 @@ public class MainActivitySourceSmokeTest {
         assertTrue(source.contains("new AppConfigSaveHandler()"));
         assertTrue(source.contains("processActionHandler.execute(item, mappedAction);"));
         assertTrue(source.contains("appConfigSaveHandler.save("));
+        assertTrue(source.contains("HyperOsNativeFontPropertySyncer.clearFontTargetAsync(packageName)"));
         assertTrue(!source.contains("private void runProcessAction(String packageName"));
         assertTrue(!source.contains("private int[] saveAppConfig(AppListItem item"));
     }
@@ -267,6 +271,14 @@ public class MainActivitySourceSmokeTest {
         assertTrue(source.contains("performHapticFeedback(resolvePressHapticConstant())"));
         assertTrue(source.contains("HapticFeedbackConstants.CONFIRM"));
         assertTrue(source.contains("HapticFeedbackConstants.VIRTUAL_KEY"));
+    }
+
+    @Test
+    public void applicationSyncsHyperOsNativeFontTargetsOnStartup() throws IOException {
+        String source = read("src/main/java/com/dpis/module/DpisApplication.java");
+
+        assertTrue(source.contains("HyperOsNativeFontPropertySyncer.syncConfiguredFontTargetsAsync(configStore)"));
+        assertTrue(source.contains("HyperOsNativeFontPropertySyncer.syncConfiguredFontTargetsAsync(remoteStore)"));
     }
 
     private static String read(String relativePath) throws IOException {

--- a/app/src/test/java/com/dpis/module/MainActivitySourceSmokeTest.java
+++ b/app/src/test/java/com/dpis/module/MainActivitySourceSmokeTest.java
@@ -91,6 +91,8 @@ public class MainActivitySourceSmokeTest {
         assertTrue(source.contains("maybeShowModuleRuntimeReloadAdvice()"));
         assertTrue(source.contains("ModuleRuntimeReloadAdvisor.shouldShowReloadAdvice(this)"));
         assertTrue(source.contains("ModuleRuntimeReloadAdvisor.markReloadAdviceAcknowledged(this)"));
+        assertTrue(source.contains("ModuleRuntimeReloader.softReloadAsync("));
+        assertTrue(source.contains("module_runtime_reload_now_button"));
         assertTrue(source.contains("maybeShowStartupDisclaimerDialog()"));
         assertTrue(source.contains("if (!maybeShowStartupDisclaimerDialog()) {"));
         assertTrue(source.contains("startupUpdateDialogCoordinator().maybeShowStartupDisclaimerDialog("));
@@ -279,6 +281,20 @@ public class MainActivitySourceSmokeTest {
 
         assertTrue(source.contains("HyperOsNativeFontPropertySyncer.syncConfiguredFontTargetsAsync(configStore)"));
         assertTrue(source.contains("HyperOsNativeFontPropertySyncer.syncConfiguredFontTargetsAsync(remoteStore)"));
+        assertTrue(!source.contains("HyperOsNativeProxyRefreshCoordinator.refreshConfiguredTargetsAsync(this, configStore)"));
+        assertTrue(!source.contains("HyperOsNativeProxyRefreshCoordinator.refreshConfiguredTargetsAsync(this, remoteStore)"));
+    }
+
+    @Test
+    public void appReceivesPackageReplacementWithoutAutoMountingHyperOsNativeProxy() throws IOException {
+        String manifest = read("src/main/AndroidManifest.xml");
+        String receiver = read("src/main/java/com/dpis/module/DpisPackageLifecycleReceiver.java");
+
+        assertTrue(manifest.contains(".DpisPackageLifecycleReceiver"));
+        assertTrue(manifest.contains("android.intent.action.MY_PACKAGE_REPLACED"));
+        assertTrue(receiver.contains("Intent.ACTION_MY_PACKAGE_REPLACED"));
+        assertTrue(receiver.contains("HyperOsNativeProxyAssetExporter.exportBundledNativeProxyLibrary(context)"));
+        assertTrue(!receiver.contains("HyperOsNativeProxyRefreshCoordinator.refreshConfiguredTargetsAsync(context, store)"));
     }
 
     private static String read(String relativePath) throws IOException {

--- a/app/src/test/java/com/dpis/module/MainActivitySourceSmokeTest.java
+++ b/app/src/test/java/com/dpis/module/MainActivitySourceSmokeTest.java
@@ -284,4 +284,16 @@ public class MainActivitySourceSmokeTest {
     private static String read(String relativePath) throws IOException {
         return new String(Files.readAllBytes(Path.of(relativePath)), StandardCharsets.UTF_8);
     }
+
+    @Test
+    public void hyperOsRestartPreparesNativeProxyBeforeProcessAction() throws IOException {
+        String source = read("src/main/java/com/dpis/module/MainActivity.java");
+
+        assertTrue(source.contains("executeDialogProcessActionAfterHyperOsProxyReady"));
+        assertTrue(source.contains("item.hyperOsNativeProxyCandidate"));
+        assertTrue(source.contains("executeHyperOsNativeProxyMount(item, true, success ->"));
+        assertTrue(source.contains("if (success)"));
+        assertTrue(source.contains("processActionHandler.execute(item, mappedAction);"));
+    }
+
 }

--- a/app/src/test/java/com/dpis/module/MainViewModelTest.java
+++ b/app/src/test/java/com/dpis/module/MainViewModelTest.java
@@ -119,6 +119,7 @@ public class MainViewModelTest {
                 FontApplyMode.OFF,
                 true,
                 systemApp,
+                false,
                 null);
     }
 }

--- a/app/src/test/java/com/dpis/module/ModuleMainHookInstallerTest.java
+++ b/app/src/test/java/com/dpis/module/ModuleMainHookInstallerTest.java
@@ -17,6 +17,30 @@ public class ModuleMainHookInstallerTest {
         assertTrue(source.contains("SystemServerMutationPolicy.shouldInstallSystemServerHooks("));
     }
 
+    @Test
+    public void moduleMainConfiguresHyperOsFlutterNativeFontHook() throws IOException {
+        String moduleMain = read("src/main/java/com/dpis/module/ModuleMain.java");
+        String nativeInit = read("src/main/resources/META-INF/xposed/native_init.list");
+        String build = read("build.gradle.kts");
+
+        assertTrue(moduleMain.contains("HyperOsFlutterFontHookInstaller.install("));
+        assertTrue(read("src/main/java/com/dpis/module/SystemServerDisplayEnvironmentInstaller.java")
+                .contains("HyperOsRustProcessHookInstaller.install("));
+        assertTrue(nativeInit.contains("libdpis_native.so"));
+        assertTrue(build.contains("externalNativeBuild"));
+    }
+
+    @Test
+    public void nativeFontHookUsesRustEnvironmentAsRuntimeFontSource() throws IOException {
+        String nativeSource = read("src/main/cpp/dpis_native.cpp");
+
+        assertTrue(nativeSource.contains("DPIS_FONT_SCALE_PERCENT"));
+        assertTrue(nativeSource.contains("std::getenv"));
+        assertTrue(nativeSource.contains("read_proc_cmdline_value"));
+        assertTrue(nativeSource.contains("value == \"false\" || value == \"disabled\""));
+        assertTrue(nativeSource.contains("return g_enabled.load(std::memory_order_relaxed)"));
+    }
+
     private static String read(String relativePath) throws IOException {
         return new String(Files.readAllBytes(Path.of(relativePath)), StandardCharsets.UTF_8);
     }

--- a/app/src/test/java/com/dpis/module/ModuleRuntimeReloadAdvisorTest.java
+++ b/app/src/test/java/com/dpis/module/ModuleRuntimeReloadAdvisorTest.java
@@ -1,0 +1,23 @@
+package com.dpis.module;
+
+import static org.junit.Assert.assertFalse;
+import static org.junit.Assert.assertTrue;
+
+import org.junit.Test;
+
+public class ModuleRuntimeReloadAdvisorTest {
+    @Test
+    public void detectsSystemServerRuntimeOlderThanCurrentInstall() {
+        assertTrue(ModuleRuntimeReloadAdvisor.isSystemServerRuntimeOlderThanInstall(
+                10_000L, 7_000L));
+    }
+
+    @Test
+    public void ignoresMissingOrCurrentSystemServerRuntime() {
+        assertFalse(ModuleRuntimeReloadAdvisor.isSystemServerRuntimeOlderThanInstall(0L, 7_000L));
+        assertFalse(ModuleRuntimeReloadAdvisor.isSystemServerRuntimeOlderThanInstall(10_000L, 0L));
+        assertFalse(ModuleRuntimeReloadAdvisor.isSystemServerRuntimeOlderThanInstall(10_000L, 9_000L));
+        assertFalse(ModuleRuntimeReloadAdvisor.isSystemServerRuntimeOlderThanInstall(10_000L, 10_000L));
+        assertFalse(ModuleRuntimeReloadAdvisor.isSystemServerRuntimeOlderThanInstall(10_000L, 12_000L));
+    }
+}

--- a/app/src/test/java/com/dpis/module/ModuleRuntimeReloadAdvisorTest.java
+++ b/app/src/test/java/com/dpis/module/ModuleRuntimeReloadAdvisorTest.java
@@ -7,6 +7,14 @@ import org.junit.Test;
 
 public class ModuleRuntimeReloadAdvisorTest {
     @Test
+    public void softReloadCommandRestartsZygoteAndSystemServer() {
+        String command = ModuleRuntimeReloader.buildSoftReloadCommandForTest();
+
+        assertTrue(command.contains("setprop ctl.restart zygote"));
+        assertTrue(command.contains("setprop ctl.restart zygote_secondary"));
+    }
+
+    @Test
     public void detectsSystemServerRuntimeOlderThanCurrentInstall() {
         assertTrue(ModuleRuntimeReloadAdvisor.isSystemServerRuntimeOlderThanInstall(
                 10_000L, 7_000L));

--- a/app/src/test/java/com/dpis/module/PerAppDisplayConfigSourceTest.java
+++ b/app/src/test/java/com/dpis/module/PerAppDisplayConfigSourceTest.java
@@ -35,6 +35,35 @@ public class PerAppDisplayConfigSourceTest {
     }
 
     @Test
+    public void returnsNullWhenTargetDpisDisabled() {
+        FakePrefs prefs = new FakePrefs();
+        DpiConfigStore store = new DpiConfigStore(prefs);
+        assertTrue(store.setTargetViewportWidthDp("com.example.target", 500));
+        assertTrue(store.setTargetFontScalePercent("com.example.target", 300));
+        assertTrue(store.setTargetFontApplyMode(
+                "com.example.target", FontApplyMode.SYSTEM_EMULATION));
+        assertTrue(store.setTargetDpisEnabled("com.example.target", false));
+
+        PerAppDisplayConfig config = new PerAppDisplayConfigSource(store)
+                .get("com.example.target");
+
+        assertNull(config);
+    }
+
+    @Test
+    public void providerReflectsUpdatedStoreOnEachRead() {
+        FakePrefs prefs = new FakePrefs();
+        DpiConfigStore store = new DpiConfigStore(prefs);
+        assertTrue(store.setTargetFontScalePercent("com.example.target", 300));
+        PerAppDisplayConfigSource source = new PerAppDisplayConfigSource(() -> store);
+        assertNotNull(source.get("com.example.target"));
+
+        assertTrue(store.clearTargetPackageConfig("com.example.target"));
+
+        assertNull(source.get("com.example.target"));
+    }
+
+    @Test
     public void keepsViewportConfigWhenViewportExists() {
         FakePrefs prefs = new FakePrefs();
         DpiConfigStore store = new DpiConfigStore(prefs);

--- a/app/src/test/java/com/dpis/module/SystemServerDisplayDiagnosticsTest.java
+++ b/app/src/test/java/com/dpis/module/SystemServerDisplayDiagnosticsTest.java
@@ -28,11 +28,12 @@ public class SystemServerDisplayDiagnosticsTest {
         configuration.screenHeightDp = 736;
         configuration.smallestScreenWidthDp = 360;
         configuration.densityDpi = 480;
+        configuration.fontScale = 1.25f;
 
         String summary = SystemServerDisplayDiagnostics.describeState(configuration, null);
 
         assertEquals(
-                "config{widthDp=360,heightDp=736,smallestWidthDp=360,densityDpi=480}",
+                "config{widthDp=360,heightDp=736,smallestWidthDp=360,densityDpi=480,fontScale=1.25}",
                 summary);
     }
 

--- a/app/src/test/java/com/dpis/module/SystemServerDisplayEnvironmentInstallerEnvironmentSelectionTest.java
+++ b/app/src/test/java/com/dpis/module/SystemServerDisplayEnvironmentInstallerEnvironmentSelectionTest.java
@@ -26,19 +26,28 @@ public class SystemServerDisplayEnvironmentInstallerEnvironmentSelectionTest {
     }
 
     @Test
-    public void systemServerOnlyUsesConfigWithViewportOverride() {
-        PerAppDisplayConfig fontOnly = new PerAppDisplayConfig(
+    public void systemServerUsesViewportOrFontEmulationConfig() {
+        PerAppDisplayConfig fontOnlyEmulation = new PerAppDisplayConfig(
                 "com.example.target",
                 null,
-                120
+                120,
+                FontApplyMode.SYSTEM_EMULATION
+        );
+        PerAppDisplayConfig fontOnlyRewrite = new PerAppDisplayConfig(
+                "com.example.target",
+                null,
+                120,
+                FontApplyMode.FIELD_REWRITE
         );
         PerAppDisplayConfig viewport = new PerAppDisplayConfig(
                 "com.example.target",
                 360
         );
 
+        assertTrue(SystemServerDisplayEnvironmentInstaller
+                .shouldUseConfigInSystemServerForTest(fontOnlyEmulation));
         assertFalse(SystemServerDisplayEnvironmentInstaller
-                .shouldUseConfigInSystemServerForTest(fontOnly));
+                .shouldUseConfigInSystemServerForTest(fontOnlyRewrite));
         assertTrue(SystemServerDisplayEnvironmentInstaller
                 .shouldUseConfigInSystemServerForTest(viewport));
     }

--- a/app/src/test/java/com/dpis/module/SystemServerDisplayEnvironmentInstallerMutationPolicyTest.java
+++ b/app/src/test/java/com/dpis/module/SystemServerDisplayEnvironmentInstallerMutationPolicyTest.java
@@ -2,6 +2,10 @@ package com.dpis.module;
 
 import org.junit.Test;
 
+import java.io.IOException;
+import java.nio.charset.StandardCharsets;
+import java.nio.file.Files;
+import java.nio.file.Path;
 import java.util.LinkedHashSet;
 import java.util.Set;
 
@@ -76,6 +80,10 @@ public class SystemServerDisplayEnvironmentInstallerMutationPolicyTest {
                 .shouldInstallTargetForTest("activity-start", true));
         assertFalse(SystemServerDisplayEnvironmentInstaller
                 .shouldInstallTargetForTest("config-dispatch", true));
+        assertFalse(SystemServerDisplayEnvironmentInstaller
+                .shouldInstallTargetForTest("launch-activity-item", true));
+        assertFalse(SystemServerDisplayEnvironmentInstaller
+                .shouldInstallTargetForTest("hyperos-rust-process", true));
     }
 
     @Test
@@ -90,6 +98,27 @@ public class SystemServerDisplayEnvironmentInstallerMutationPolicyTest {
                 .shouldInstallTargetForTest("activity-start", false));
         assertTrue(SystemServerDisplayEnvironmentInstaller
                 .shouldInstallTargetForTest("config-dispatch", false));
+        assertTrue(SystemServerDisplayEnvironmentInstaller
+                .shouldInstallTargetForTest("launch-activity-item", false));
+        assertTrue(SystemServerDisplayEnvironmentInstaller
+                .shouldInstallTargetForTest("hyperos-rust-process", false));
+    }
+
+    @Test
+    public void hyperOsBootstrapHooksAreGuardedBySafeModeInSource() throws IOException {
+        String source = read("src/main/java/com/dpis/module/SystemServerDisplayEnvironmentInstaller.java");
+
+        int launchHookIndex = source.indexOf("if (installLaunchActivityItemHook(xposed, source))");
+        assertTrue(launchHookIndex > 0);
+        String launchContext = source.substring(Math.max(0, launchHookIndex - 260), launchHookIndex);
+        assertTrue(launchContext.contains("shouldInstallTarget("));
+        assertTrue(launchContext.contains("launch-activity-item"));
+
+        int rustHookIndex = source.indexOf("if (HyperOsRustProcessHookInstaller.install(xposed, source))");
+        assertTrue(rustHookIndex > 0);
+        String rustContext = source.substring(Math.max(0, rustHookIndex - 260), rustHookIndex);
+        assertTrue(rustContext.contains("shouldInstallTarget("));
+        assertTrue(rustContext.contains("hyperos-rust-process"));
     }
 
     @Test
@@ -123,6 +152,10 @@ public class SystemServerDisplayEnvironmentInstallerMutationPolicyTest {
         assertEquals(800L, SystemServerHookLogGate.resolveLogMinIntervalMs("activity-start"));
         assertEquals(800L, SystemServerHookLogGate.resolveLogMinIntervalMs("config-dispatch"));
         assertEquals(400L, SystemServerHookLogGate.resolveLogMinIntervalMs("unknown-entry"));
+    }
+
+    private static String read(String relativePath) throws IOException {
+        return new String(Files.readAllBytes(Path.of(relativePath)), StandardCharsets.UTF_8);
     }
 
     private static final class FakeWindow {

--- a/app/src/test/java/com/dpis/module/SystemServerSettingsLayoutSmokeTest.java
+++ b/app/src/test/java/com/dpis/module/SystemServerSettingsLayoutSmokeTest.java
@@ -37,6 +37,7 @@ public class SystemServerSettingsLayoutSmokeTest {
         String strings = read("src/main/res/values/strings.xml");
 
         assertTrue(strings.contains("settings_section_other"));
+        assertTrue(strings.contains("settings_hyperos_flutter_font_hook_label"));
         assertTrue(strings.contains("settings_about_label"));
         assertTrue(strings.contains("settings_config_backup_label"));
         assertTrue(strings.contains("config_backup_confirm_import_action"));
@@ -52,6 +53,8 @@ public class SystemServerSettingsLayoutSmokeTest {
     public void settingsRowsUseSemanticIcons() throws IOException {
         String source = read("src/main/java/com/dpis/module/SystemServerSettingsActivity.java");
 
+        assertTrue(source.contains("R.id.row_hyperos_flutter_font_hook"));
+        assertTrue(source.contains("R.drawable.baseline_tune_24"));
         assertTrue(source.contains("R.drawable.baseline_upload_file_24"));
         assertTrue(source.contains("R.drawable.ic_language_24"));
         assertTrue(source.contains("R.drawable.outline_image_not_supported_24"));

--- a/app/src/test/java/com/dpis/module/SystemServerSettingsLayoutSmokeTest.java
+++ b/app/src/test/java/com/dpis/module/SystemServerSettingsLayoutSmokeTest.java
@@ -61,6 +61,14 @@ public class SystemServerSettingsLayoutSmokeTest {
     }
 
     @Test
+    public void disablingHyperOsFontHookClearsPublishedFontTargets() throws IOException {
+        String source = read("src/main/java/com/dpis/module/SystemServerSettingsActivity.java");
+
+        assertTrue(source.contains("if (!isChecked) {"));
+        assertTrue(source.contains("HyperOsNativeFontPropertySyncer.clearConfiguredFontTargetsAsync(store);"));
+    }
+
+    @Test
     public void configBackupDialogsUseCustomLayoutStructure() throws IOException {
         String actionDialog = read("src/main/res/layout/dialog_config_backup.xml");
         String confirmDialog = read("src/main/res/layout/dialog_config_backup_confirm.xml");

--- a/docs/hyperos-font-debug-progress.md
+++ b/docs/hyperos-font-debug-progress.md
@@ -1,0 +1,63 @@
+# HyperOS Rust Font Debug Progress
+
+This document tracks the HyperOS Rust/Flutter font investigation. New experiments, logs, and conclusions should be appended here.
+
+## Current conclusions
+
+- Normal Java apps mainly use app-process Java/Xposed hooks. Restarting the target app usually reloads the new app-process hooks.
+- HyperOS Gallery and Weather also depend on the system_server `RustProcessImpl.startRustProcess` hook.
+- Gallery text is mainly controlled through native paragraph hooks in `libhyper_os_flutter.so`, not Java `TextView` or `Paint`.
+- Reinstalling DPIS does not reload already-running system_server module code. This limitation is specific to system_server/HyperOS Rust paths, not all apps.
+- Runtime font values can be hot-published through root `setprop debug.dpis.font.<hash> <percent>` once the native proxy is already deployed and used by Gallery.
+
+## Main runtime chain
+
+- system_server hook: `HyperOsRustProcessHookInstaller` hooks `android.os.RustProcessImpl.startRustProcess`.
+- Rust proxy: Gallery startup binary is redirected from `libapp_gallery.so` to sibling `libdpis_native.so`.
+- Original binary path: `debug.dpis.rustbin.<hash>` points back to the original `libapp_gallery.so`.
+- Font config: `debug.dpis.font.<hash>` or `debug.dpis.forcefont` provides the target percentage.
+- Paragraph hooks: `ParagraphBuilder::Create` offset `0x81c368`, `ParagraphBuilder::pushStyle` offset `0x82370c`.
+
+## Completed fixes
+
+- Added native proxy build/load files: `app/src/main/cpp/dpis_native.cpp`, `app/src/main/cpp/CMakeLists.txt`, `app/src/main/assets/native_init`.
+- Added HyperOS Rust process startup hook: `HyperOsRustProcessHookInstaller`.
+- Added HyperOS Flutter font bridge: `HyperOsFlutterFontBridge`.
+- Added native property cleaner: `HyperOsNativeFontPropertySyncer` clears `debug.dpis.font.<hash>` and `debug.dpis.rustbin.<hash>`.
+- Fixed stale native property reset behavior when font config is cleared or the target package is disabled.
+- Fixed local/remote config migration residue so removed target packages are not revived by old remote config.
+- Fixed system_server config caching by making `PerAppDisplayConfigSource` use a dynamic StoreProvider.
+- Added native proxy status UI: `HyperOsNativeProxyStatus`.
+- Narrowed stale system_server runtime warning with `debug.dpis.module.system_server_loaded_at`.
+- Hardened debug bridge components by marking them non-exported and removing `READ_LOGS`.
+
+## 2026-04-27 Gallery font hot-publish bypass
+
+- Goal: explain why normal Java apps can update after reinstall while HyperOS Gallery often needed a device reboot after same-version debug reinstall.
+- Two explorer agents and local chain checks reached the same direction: do not switch the main path to RustPaint/RustCanvas/font cache hooks. Keep `RustProcessImpl.startRustProcess` -> sibling `libdpis_native.so` -> `libhyper_os_flutter.so` paragraph hooks as the stable path.
+- Device evidence: the Gallery process has loaded `libdpis_native.so`, `libapp_gallery.so`, and `libhyper_os_flutter.so`.
+- Device properties: `debug.dpis.font.a55b5fe1=100`, `debug.dpis.rustbin.a55b5fe1=/data/app/MIUIGallery/lib/arm64/libapp_gallery.so`.
+- New practical route: if only the font percentage changes, DPIS can directly root-set `debug.dpis.forcefont.<hash>` and let the already-deployed native proxy read the new value.
+- Code change: `AppConfigSaveHandler` now calls `HyperOsNativeFontPropertySyncer.publishForceFontTargetAsync(...)` when saving an enabled font config.
+- Boundary: clearing or disabling font config still clears font/rustbin properties. Changes to RustProcess hook code or proxy deployment still require restarting system_server or the device.
+
+## Next verification
+
+1. Install the new debug APK without rebooting the device.
+2. Change Gallery font to a visible value, for example 300%.
+3. Check `adb -s d7121fb5 shell su -c getprop debug.dpis.font.a55b5fe1` immediately.
+4. Only force-stop/restart Gallery.
+5. Check for `ParagraphBuilder::Create override` or `ParagraphBuilder::pushStyle override` logs and confirm the multiplier matches the new value.
+
+## Verification record
+
+- `./gradlew.bat :app:testDebugUnitTest`: passed.
+- `./gradlew.bat :app:assembleDebug`: passed.
+
+## 2026-04-27 Force property bypass confirmed
+
+- Evidence: DPIS app startup changed `debug.dpis.forcefont.a55b5fe1` to `300`, while old system_server code still rewrote `debug.dpis.font.a55b5fe1` to `50` during Gallery startup.
+- Fix direction: native now reads `debug.dpis.forcefont.<hash>` before global `debug.dpis.forcefont`, env/cmdline, and `debug.dpis.font.<hash>`.
+- Device verification: after replacing Gallery sibling `libdpis_native.so`, restarting only Gallery produced `ParagraphBuilder::Create/pushStyle multiplier=2.000000` even though system_server still emitted `DPIS_FONT_SCALE_PERCENT=50`.
+- Meaning: font percentage changes can bypass stale system_server config as long as the target app uses the updated native proxy.
+- Remaining boundary: changes to the Java RustProcess hook or proxy deployment path still require system_server/device restart.

--- a/docs/hyperos-font-injection-research-plan.md
+++ b/docs/hyperos-font-injection-research-plan.md
@@ -1,0 +1,26 @@
+# HyperOS Font Injection Progress
+
+## Current Conclusion
+
+- HyperOS Gallery/Weather can bypass normal Java-only hooks through a Rust/Flutter native path.
+- The supported path is the target-app sibling proxy `libdpis_native.so`, prepared by DPIS and loaded by the HyperOS Rust process hook.
+- DP/font runtime values are published through package-hash system properties so repeated value changes do not require replacing native files again.
+- The UI keeps this as part of normal Save/Reset behavior instead of exposing separate proxy buttons.
+
+## User-Facing Flow
+
+- Save non-empty DP/font config: DPIS writes config and prepares HyperOS compatibility support when applicable.
+- Save empty config: DPIS clears config and rolls back HyperOS compatibility support when applicable.
+- Reset button only clears dialog inputs; the rollback happens after saving, keeping persisted config and runtime state aligned.
+- Success is intentionally quiet; failures show a concise compatibility setup/rollback error.
+
+## Technical Notes
+
+- The mount helper uses strict command chaining and fixed-string mount checks so failed bind mounts do not report success.
+- The Rust process hook no longer contains the temporary external-path or `LD_PRELOAD` experiment branches.
+- Remaining improvement: shared root/setprop helper can reduce duplication between font and viewport runtime property syncers.
+
+## Validation
+
+- `./gradlew :app:testDebugUnitTest`
+- `./gradlew :app:assembleDebug`

--- a/docs/hyperos-font-injection-research-plan.md
+++ b/docs/hyperos-font-injection-research-plan.md
@@ -24,3 +24,49 @@
 
 - `./gradlew :app:testDebugUnitTest`
 - `./gradlew :app:assembleDebug`
+
+## Weather 2026-04-28 Fix
+
+- `com.miui.weather2` hash is `4568f00f`; runtime config was correctly published as `debug.dpis.forcefont.4568f00f=300` and `debug.dpis.vp.4568f00f=500`.
+- Weather failed earlier for two separate reasons:
+  - its native directory did not already contain `libdpis_native.so`, so the old mount planner rejected first-time proxy setup;
+  - native config refresh returned immediately after JNI/env configuration, so the runtime `forcefont` property could not override the stale `DPIS_FONT_SCALE_PERCENT=100` value.
+- Fixes:
+  - proxy setup now accepts an existing target native directory even when the target mount-point file is missing, and the root apply command creates the file before bind mount;
+  - native font config priority is now `debug.dpis.forcefont.<hash>` -> `debug.dpis.forcefont` -> existing JNI/env/default state, so runtime Weather values can override the process-start value.
+- Regression coverage:
+  - missing target mount point is valid when the parent native directory exists;
+  - missing parent native directory still fails early;
+  - apply command creates the mount point and still verifies mount/hash;
+  - native source smoke test guards against reintroducing the JNI early-return priority bug.
+- Additional Weather evidence: after the proxy loaded, `ParagraphBuilder::Create` logged `d1=0.000000` and multiplier stayed `1.000000`; this means Weather's Flutter build does not pass the observed font scale through the same Create argument used by Gallery.
+- Additional fix: Create-hook scale calculation now falls back to an observed scale of `1.0` when the observed argument is zero/invalid, and the Create trampoline no longer scales the sentinel `d0` register. This keeps Gallery's normal path while allowing Weather's `d2` font-size argument to receive the configured multiplier.
+
+## Weather Blank UI After Reboot 2026-04-28
+
+- Root cause: bind mounts do not survive device reboot, but the Weather target mount-point file created by `touch` stayed behind as a 0-byte `/data/app/MIUIWeather/lib/arm64/libdpis_native.so`.
+- Failure mode: old system_server hook could still redirect Weather's Rust binary to that sibling path, so Weather attempted to start through an empty native file and only reached a blank/background state.
+- Fixes:
+  - Rust process proxy resolution now requires sibling `libdpis_native.so` to be a non-empty file before redirecting the Rust binary.
+  - proxy status inspection also treats a 0-byte placeholder as missing, not present.
+- Immediate device recovery used during verification: remove the stale 0-byte target file, then restart Weather. Weather resumed normal logs without DPIS native injection.
+- Operational note: after a device reboot, HyperOS native proxy support must be prepared again before launching target apps if the bind mount was lost.
+- Follow-up: installing a new APK does not immediately refresh the already-loaded LSPosed code inside `system_server`; before reboot, stale code may still redirect to a leftover 0-byte sibling file.
+- Additional hardening: proxy apply now refuses to overwrite a non-empty target unless it already matches DPIS's proxy, then copies the proxy and removes only matching DPIS-owned copies during rollback.
+- Clarification: DPIS's app restart button only force-stops and starts the target app; it does not reload LSPosed code already resident in `system_server`.
+- Fix: for HyperOS native proxy candidates with a configured font scale, the DPIS restart button now prepares/rebinds the native proxy first, then restarts the target app.
+- Follow-up: Android shell parsing differs between `adb shell su -c ...` and Java `ProcessBuilder("su", "-c", command)`, and grouped `(...)` commands are fragile on this device path. The prepare command was rewritten to avoid parenthesized groups and use mksh-compatible copy/remove commands.
+- Device validation: with the rewritten command form, preparing `/data/app/MIUIWeather/lib/arm64/libdpis_native.so` succeeds and Weather starts as process `23901`.
+
+## Weather FontScale Native GOT Path 2026-04-28
+
+- New evidence: Weather's visible font path does not reliably use Gallery's `ParagraphBuilder`/TextStyle construction offsets as the primary source of truth.
+- `libweather_app.so` imports `Configuration_get_font_scale` from the HyperOS public/native API layer and calls it during startup.
+- A same-name export in `libdpis_native.so` alone does not intercept the call; the weather Rust library resolves its own PLT/GOT entry.
+- Verified route: patch `libweather_app.so`'s `Configuration_get_font_scale` GOT slot to DPIS's native override after the original Rust library is loaded.
+- Device evidence:
+  - GOT hook installed for `com.miui.weather2`.
+  - `Configuration_get_font_scale` override logs `value=3.000000` under a 300% font config.
+  - Weather process stays alive after launch; unrelated `com.xiaomi.market` crashes appeared in logcat and are not the Weather process.
+- Cleanup: removed the temporary Weather TextStyle/entry probe because it was not the root path and could confuse validation.
+- Remaining visual validation: user should confirm whether all Weather text now visibly follows the configured font scale; logs only prove the native font-scale source is overridden.

--- a/docs/hyperos-gallery-display-font-chain.md
+++ b/docs/hyperos-gallery-display-font-chain.md
@@ -1,0 +1,280 @@
+# HyperOS Gallery DP and Font Logic Chain
+
+本文解释 `com.miui.gallery` 在 DPIS 中的 DP、字体伪装、字体替换、HyperOS Rust/Flutter native hook 的完整链路。它基于当前代码、实机调试日志和相册最新包验证结果整理。
+
+## 当前结论
+
+- `com.miui.gallery` 不是内置白名单目标；只有用户在 DPIS 中配置后才进入 `target_packages`。
+- 普通 Java 应用和 Gallery 的生效链路不同，不能把 Gallery 的问题泛化为所有应用都必须重启设备。
+- 普通 Java 应用通常在目标进程重启后就能重新加载 app 进程 hook，因此覆盖安装 DPIS 后往往可以即时调整。
+- Gallery 的关键 DP/字体链路额外依赖 `system_server` 和 HyperOS RustProcess hook；覆盖安装 DPIS 不会让已运行的 `system_server` 自动重新加载新模块代码。
+- 普通字体伪装主要通过 `Configuration.fontScale` 下发，但 Gallery 的 Flutter 文本不会完全服从这条 Java 链路。
+- Gallery 的最终可控字体入口在 HyperOS Rust/Flutter native 链路：`RustProcessImpl.startRustProcess` → sibling `libdpis_native.so` → `libhyper_os_flutter.so` 的 paragraph 构建入口。
+- “重置后仍保持旧字体”的根因曾是 native system property 残留，而不是 DPIS UI 配置未删除；当前已通过 `HyperOsNativeFontPropertySyncer` 修复。
+
+## 1. 配置层
+
+Gallery 的配置由 `dpi_config` 保存，核心 key 如下：
+
+- `target_packages`：目标包集合，Gallery 只有被配置后才会加入。
+- `viewport.com.miui.gallery.width_dp`：目标视口宽度。
+- `viewport.com.miui.gallery.mode`：DP/视口模式，常见为 `system_emulation` 或 `field_rewrite`。
+- `font.com.miui.gallery.scale_percent`：目标字体百分比，范围 `50..300`。
+- `font.com.miui.gallery.mode`：字体模式，常见为 `system_emulation` 或 `field_rewrite`。
+- `target.com.miui.gallery.dpis_enabled`：临时禁用开关；`false` 表示保留配置但运行时不应用。
+- `font.hyperos_flutter_hook_enabled`：实验性 HyperOS Flutter 字体 hook 总开关。
+
+关键代码：
+
+- `app/src/main/java/com/dpis/module/DpiConfigStore.java`
+- `app/src/main/java/com/dpis/module/AppConfigSaveHandler.java`
+- `app/src/main/java/com/dpis/module/PerAppDisplayConfigSource.java`
+- `app/src/main/java/com/dpis/module/TargetViewportWidthResolver.java`
+
+### 保存与重置
+
+- 清空输入框只是修改 UI 状态；真正写入发生在点击保存后。
+- 清空 DP 输入并保存，会移除 `viewport.*.width_dp` 和 `viewport.*.mode`。
+- 清空字体输入并保存，会移除 `font.*.scale_percent` 和 `font.*.mode`，并调用 `HyperOsNativeFontPropertySyncer.clearFontTargetAsync(...)` 清理 native 属性。
+- 如果 DP 和字体都清空，Gallery 会从 `target_packages` 移除。
+- 点击“已启用/启用修改”这类 DPIS 开关，写的是 `target.<pkg>.dpis_enabled=false`；它不会删除旧配置，只是运行时屏蔽。
+
+## 2. DP / 视口链路
+
+DPIS 对 Gallery 的 DP/视口有两条路径：
+
+1. app 进程 Java hook：处理 `Resources`、`Display`、`WindowMetrics` 等 Java 层查询。
+2. system_server hook：处理启动、窗口、DisplayInfo、Configuration 等系统侧来源。
+
+system_server 的主要入口是 `SystemServerDisplayEnvironmentInstaller`：
+
+- 每次命中 hook 时通过 `PerAppDisplayConfigSource` 重新读配置。
+- 如果 `target.com.miui.gallery.dpis_enabled=false`，`source.get("com.miui.gallery")` 返回 `null`。
+- 如果 Gallery 有有效视口宽度，计算目标 `Configuration.screenWidthDp`、`screenHeightDp`、`smallestScreenWidthDp`、`densityDpi`。
+- 对部分路径还会调整 frame、DisplayInfo、WindowMetrics 相关对象。
+
+恢复默认的条件：
+
+- 删除 `viewport.com.miui.gallery.*` 并保存。
+- 或把 `target.com.miui.gallery.dpis_enabled=false` 作为临时屏蔽。
+- 重启 Gallery，必要时重启 system_server/设备以清掉运行中缓存。
+
+## 3. 普通字体链路
+
+字体配置由 `font.com.miui.gallery.scale_percent` 和 `font.com.miui.gallery.mode` 决定。
+
+### 伪装模式
+
+`font.mode=system_emulation` 时，system_server/app Java 链路会尝试写入或伪装 `Configuration.fontScale`。
+
+这条链路对普通 Android View/TextView 更有效，但 Gallery 的关键界面大量走 HyperOS Flutter/Rust，因此只靠 `fontScale` 不能保证最终文本变化。
+
+### 替换/兜底模式
+
+`font.mode=field_rewrite` 时，system_server 不把它当成 `fontScale` 伪装配置；Java app 进程中会走 `Paint`、`TextPaint`、`TextView`、span、WebView 等兜底 hook。
+
+这条链路对普通 Java 文本有效，但 Gallery 的 Flutter 文本仍可能绕过 Java hook。
+
+## 4. HyperOS Rust / Flutter native 链路
+
+Gallery 的关键字体效果最终由 native 链路控制。
+
+### 启动拦截
+
+`HyperOsRustProcessHookInstaller` 在 system_server 中 hook：
+
+- 类：`android.os.RustProcessImpl`
+- 方法：`startRustProcess`
+- package 参数：`args[1]`
+- 原始 Rust so 路径：`args[20]`
+- env 参数：`args[21]`
+
+对 Gallery，如果配置有效，它会：
+
+- 发布 `debug.dpis.font.a55b5fe1=<percent>`。
+- 发布 `debug.dpis.rustbin.a55b5fe1=<原始 libapp_gallery.so 路径>`。
+- 尝试把启动 binary path 改为原始 so 同目录下的 sibling `libdpis_native.so`。
+- 追加 `DPIS_PACKAGE`、`DPIS_FONT_SCALE_PERCENT`、`DPIS_RUST_BINARY` 到 Rust env 字符串中。
+
+Gallery 的 hash：
+
+- `com.miui.gallery` → `a55b5fe1`
+- 字体属性：`debug.dpis.font.a55b5fe1`
+- 原始 binary 属性：`debug.dpis.rustbin.a55b5fe1`
+
+### Native proxy
+
+`libdpis_native.so` 必须位于 Gallery 原始 native lib 目录，例如：
+
+```text
+/data/app/MIUIGallery/lib/arm64/libdpis_native.so
+```
+
+原因是 HyperOS Rust spawner 的 namespace 更容易接受目标应用 native 目录中的 sibling so。DPIS APK 自己携带的 so 只能保证 DPIS 自身加载，不能保证 Gallery Rust 进程能直接加载。
+
+当前 DPIS 做了检测提示：
+
+- `HyperOsNativeProxyStatus` 读取 `ApplicationInfo.nativeLibraryDir`。
+- 检查目标目录中是否存在 `libdpis_native.so`。
+- 应用配置弹窗显示“已检测到 / 未检测到 / 无法检测”。
+
+### Flutter 文本 hook
+
+`app/src/main/cpp/dpis_native.cpp` 的主要逻辑：
+
+- 读取 `debug.dpis.forcefont`，作为最高优先级调试覆盖。
+- 尝试读取 env / cmdline 中的 `DPIS_FONT_SCALE_PERCENT`。
+- 读取 `debug.dpis.font.<hash>` 作为正式字体目标。
+- 读取 `debug.dpis.rustbin.<hash>` 并 `dlopen()` 原始 `libapp_gallery.so`。
+- 转发原始 `app_entry_point()`，保证 Gallery 正常启动。
+- hook `libhyper_os_flutter.so` 的文本入口。
+
+当前关键 offset：
+
+- `ParagraphBuilder::Create`：`0x81c368`
+- `ParagraphBuilder::pushStyle`：`0x82370c`
+
+当前稳定主路线是 `ParagraphBuilder::Create`；`pushStyle` 更依赖函数签名和寄存器约定，只应作为实验路径。
+
+## 5. Gallery 生效条件
+
+### DP / 视口生效
+
+- Gallery 在 `target_packages` 中，或有有效 per-package 配置。
+- `target.com.miui.gallery.dpis_enabled` 没有被设为 `false`。
+- `viewport.com.miui.gallery.width_dp` 有效。
+- mode 最终不是 `off`。
+- app 进程和 system_server 对应 hook 已安装。
+- 重启 Gallery 后读取新配置。
+
+### 普通字体伪装生效
+
+- `font.com.miui.gallery.scale_percent` 有效。
+- `font.com.miui.gallery.mode=system_emulation`。
+- system_server/app Java hook 能改到 `Configuration.fontScale`。
+- 目标文字确实走 Android Java 文本路径。
+
+### HyperOS Flutter 字体生效
+
+- Gallery 字体百分比有效。
+- system_server hook 能拦到 `RustProcessImpl.startRustProcess`。
+- `debug.dpis.font.a55b5fe1` 发布为正数。
+- `debug.dpis.rustbin.a55b5fe1` 指向原始 `libapp_gallery.so`。
+- Gallery native 目录存在 sibling `libdpis_native.so`。
+- Gallery 重启后通过代理启动。
+- `libhyper_os_flutter.so` 版本仍匹配当前 offset。
+
+## 6. 恢复默认条件
+
+完整恢复默认需要清理三类状态。
+
+### 配置层
+
+- 清空 DP 输入并保存。
+- 清空字体输入并保存。
+- 或禁用该目标包的 DPIS 修改。
+
+### Native 属性层
+
+当前代码会自动清理：
+
+- `debug.dpis.font.a55b5fe1=0`
+- `debug.dpis.rustbin.a55b5fe1=0`
+
+如果曾做过手动调试，还应确认：
+
+- `debug.dpis.forcefont=0`
+- `debug.dpis.pushstyle` 为空或关闭。
+
+### 运行中进程
+
+- force-stop / 重启 Gallery。
+- 如果 system_server hook 代码刚更新，可能需要重启设备或 system_server。
+- 如果要完全退出 native proxy 链路，需要移除 Gallery native 目录中的 sibling `libdpis_native.so` 并重启 Gallery。
+
+## 7. 本轮实机经验
+
+这次“相册重置后仍不像默认”的证据链：
+
+- `dpi_config.xml` 中已经没有 `com.miui.gallery`，说明 UI 配置清理成功。
+- 设备上仍存在 `debug.dpis.font.a55b5fe1=50`，说明 native 属性层残留。
+- Gallery 目录仍存在 `/data/app/MIUIGallery/lib/arm64/libdpis_native.so`，所以 native proxy 仍可能参与启动。
+- 手动把 `debug.dpis.font.a55b5fe1`、`debug.dpis.rustbin.a55b5fe1`、`debug.dpis.forcefont` 置为 `0` 后，用户确认相册恢复正常。
+- 因此根因不是配置保存失败，而是 native 属性没有随配置重置同步清理。
+
+对应修复：
+
+- `HyperOsNativeFontPropertySyncer.clearFontTargetAsync(...)` 在字体配置清空和目标包禁用时清理 native 属性。
+- `HyperOsFlutterFontBridge.clearTarget(...)` 同时清理 font 和 rustbin 属性。
+- 清理值统一写为 `0`，避免空字符串在 shell/root 环境中转义出错。
+
+## 8. 覆盖安装 DPIS 后的分叉链路
+
+同版本 debug APK 覆盖安装 DPIS 后，Android 会替换 APK，并重启 DPIS 自己的 app 进程。
+
+这时要分两类：
+
+- 普通 Java 应用：目标 app 重启后通常会重新加载 DPIS app 进程 hook，因此可以立刻调整。
+- Gallery / HyperOS Rust 应用：关键路径还依赖已运行的 `system_server` 中的 RustProcess/system_server hook；覆盖安装不会让 `system_server` 自动重新加载新模块代码，因此可能需要重启设备或重启 system_server/模块运行时。
+
+这解释了用户观察到的现象：普通 Java 软件覆盖安装后可立即调整，但 HyperOS 相册需要重启后才正确应用。
+
+## 8.1 本轮深挖：重装后不重启设备的可行旁路
+
+两名子代理和本地实机链路核对后结论一致：不要把方向切到更底层的 RustPaint、RustCanvas、字体缓存或 Java TextView 扩散 hook。当前最稳的是把 native proxy 视为稳定加载器，把字体百分比做成可热发布配置。
+
+关键观察：
+
+- 当前相册进程已经加载 `/data/app/MIUIGallery/lib/arm64/libdpis_native.so`、`libapp_gallery.so`、`libhyper_os_flutter.so`。
+- 当前属性为 `debug.dpis.font.a55b5fe1=100`，`debug.dpis.rustbin.a55b5fe1=/data/app/MIUIGallery/lib/arm64/libapp_gallery.so`。
+- `dpis_native.cpp` 的 `multiplier_for(...)` 会在 paragraph 命中时刷新并读取 `debug.dpis.font.<hash>` / `debug.dpis.forcefont`。
+- 因此，若只是修改字体百分比，理论上不必等待 system_server 再次发布；DPIS app 可以直接用 root `setprop debug.dpis.font.a55b5fe1 <percent>`，然后重启 Gallery 即可让 native proxy 读到新值。
+
+本轮代码修复：
+
+- `AppConfigSaveHandler` 在保存非空且字体模式启用时调用 `HyperOsNativeFontPropertySyncer.publishForceFontTargetAsync(...)`。
+- `HyperOsNativeFontPropertySyncer` 新增 root `setprop` 发布路径，只更新 `debug.dpis.font.<hash>`，不清理 `debug.dpis.rustbin.<hash>`。
+- 字体模式关闭或字体输入清空时仍走清理路径，把 font/rustbin 属性置为 `0`，避免 stale multiplier 残留。
+
+这条旁路能解决的是“配置值变化后让已部署 native proxy 读到新值”。它不能解决的是“覆盖安装后 system_server 仍运行旧 Java hook 代码”。如果修改了 `HyperOsRustProcessHookInstaller` 本身、RustProcess 参数处理或 native proxy 部署逻辑，仍需要重启 system_server/设备。
+## 9. 风险和边界
+
+- Gallery 更新可能替换 `libhyper_os_flutter.so`，导致固定 offset 失效。
+- Gallery 更新可能覆盖 native lib 目录，导致 sibling `libdpis_native.so` 消失，需要重新检测/部署。
+- `RustProcessImpl.startRustProcess` 参数位置依赖当前 HyperOS 实现，系统更新后可能变化。
+- 运行中 Gallery 可能缓存旧 `Configuration`、Resources、DisplayInfo、env 或 native property，需要重启进程。
+- `dpis_enabled=false` 是临时屏蔽，不是删除配置；重新启用会恢复原值。
+- 100% 字体通常等同无变化，但配置仍可能存在。
+- 无 root 时 native 属性清理器的 `su setprop` 兜底可能失败；Java 层 system property 清理是否成功取决于运行进程权限。
+
+## 10. 快速排查命令
+
+Gallery 当前属性：
+
+```powershell
+adb -s d7121fb5 shell su -c getprop debug.dpis.font.a55b5fe1
+adb -s d7121fb5 shell su -c getprop debug.dpis.rustbin.a55b5fe1
+adb -s d7121fb5 shell su -c getprop debug.dpis.forcefont
+adb -s d7121fb5 shell su -c getprop debug.dpis.pushstyle
+```
+
+Gallery native proxy：
+
+```powershell
+adb -s d7121fb5 shell su -c "ls -l /data/app/MIUIGallery/lib/arm64/libdpis_native.so"
+```
+
+Gallery 配置残留：
+
+```powershell
+adb -s d7121fb5 shell su -c "grep -n 'com.miui.gallery\|font\.hyperos\|target_packages' /data/user/0/io.github.kwensiu.dpis/shared_prefs/dpi_config.xml"
+```
+
+恢复默认的手动兜底：
+
+```powershell
+adb -s d7121fb5 shell su -c setprop debug.dpis.font.a55b5fe1 0
+adb -s d7121fb5 shell su -c setprop debug.dpis.rustbin.a55b5fe1 0
+adb -s d7121fb5 shell su -c setprop debug.dpis.forcefont 0
+adb -s d7121fb5 shell su -c am force-stop com.miui.gallery
+```

--- a/docs/hyperos-native-proxy-alternatives.md
+++ b/docs/hyperos-native-proxy-alternatives.md
@@ -1,0 +1,194 @@
+# HyperOS Native Proxy 替代方案评估
+
+本文档独立记录 HyperOS Gallery/Weather 字体 hook 中，除了“把新版 `libdpis_native.so` 落到目标应用 native 目录”之外的替代方案、风险和取舍。
+
+## 背景
+
+当前 HyperOS Gallery 的 Rust/Flutter 进程不是普通 Java View/TextView 链路。DPIS 的有效链路是：
+
+1. `system_server` 中 hook `android.os.RustProcessImpl.startRustProcess`。
+2. 把原本的 Rust binary `/data/app/MIUIGallery/lib/arm64/libapp_gallery.so` 改成 sibling proxy：`/data/app/MIUIGallery/lib/arm64/libdpis_native.so`。
+3. `libdpis_native.so` 再读取 `debug.dpis.rustbin.<hash>` 并 `dlopen()` 原始 `libapp_gallery.so`。
+4. proxy 在目标进程内 hook `libhyper_os_flutter.so` 的 paragraph 入口。
+
+因此，只要改动了 `app/src/main/cpp/dpis_native.cpp`，目标应用实际加载的 native 代码就必须更新。覆盖安装 DPIS APK 只能更新 APK 内的 so，不会自动更新已经落在 Gallery native 目录里的 sibling so。
+
+## 当前确定方案：更新 sibling `libdpis_native.so`
+
+路径示例：
+
+```text
+/data/app/MIUIGallery/lib/arm64/libdpis_native.so
+```
+
+优点：
+
+- 与当前 HyperOS spawner/linker namespace 行为匹配。
+- 已实机验证可启动、可 hook、可读取新 `debug.dpis.forcefont.<hash>`。
+- 生效路径确定：Gallery 启动时实际加载的就是这个文件。
+- 可做成可检测、可校验、可回滚的流程。
+
+缺点：
+
+- 需要 root 写目标应用安装目录。
+- 改 native 代码后必须同步这个文件。
+- 目标应用更新后可能覆盖或移动 native 目录。
+- 固定 offset 仍可能随 Gallery/HyperOS 更新失效。
+
+建议产品化方式：
+
+- DPIS UI 检测目标目录是否存在 sibling proxy。
+- 比较 APK 内新版 proxy 与目标目录 proxy 的 hash/size。
+- 不一致时提示用户“需要更新 HyperOS native proxy”。
+- 操作前 force-stop 目标应用。
+- root 复制到临时路径，再复制到目标 native 目录。
+- 复制后校验 hash/size。
+- 提供一键回滚：删除目标目录中的 `libdpis_native.so`。
+
+## 替代方案 1：只靠 system_server 传 env/property
+
+做法：不更新 native proxy，只让 `system_server` 通过 env 或 system property 传递新字体百分比。
+
+结论：只能更新配置，不能更新 native 代码。
+
+适用场景：
+
+- 只改字体百分比、开关、实验参数。
+- 目标应用已经加载了支持这些配置的新版 proxy。
+
+不适用场景：
+
+- 修改了 `dpis_native.cpp` 的读取逻辑、hook 逻辑、offset 处理、trampoline 代码。
+- 目标目录里的 proxy 仍是旧版本。
+
+本轮实机证据：
+
+- DPIS 可以写 `debug.dpis.forcefont.a55b5fe1=300`。
+- 旧 `system_server` 仍会把 `debug.dpis.font.a55b5fe1` 覆盖为 `50`。
+- 只有当目标目录里的新版 proxy 支持优先读取 `debug.dpis.forcefont.<hash>` 后，Gallery 才绕过旧值并得到 `multiplier=2.0`。
+
+## 替代方案 2：让目标进程直接加载 DPIS APK 里的 so
+
+做法：不复制到 Gallery 目录，尝试从 DPIS APK 或 DPIS 私有目录加载 `libdpis_native.so`。
+
+结论：理论上更干净，但当前不稳定，不作为主线。
+
+问题：
+
+- HyperOS Rust spawner/linker namespace 对可见 library path 有限制。
+- Gallery Rust 进程更容易接受自身 native 目录下的 sibling so。
+- DPIS APK 私有目录通常不在 Gallery namespace 的可加载路径内。
+- 即使拿到绝对路径，依赖库、namespace、SELinux 和 linker 规则也可能失败。
+
+适用价值：
+
+- 可作为未来研究方向。
+- 如果能稳定把 DPIS APK 内 so 暴露到 Gallery namespace，就能避免写目标应用目录。
+
+当前判断：不作为近期方案。
+
+## 替代方案 3：LSPosed native_init / 普通 app 进程注入
+
+做法：依赖 LSPosed native_init 或普通 app 进程 hook，在 Gallery 进程内加载 native hook。
+
+结论：对普通 Android app 更适合，对 HyperOS Gallery Rust 主进程不稳定。
+
+问题：
+
+- Gallery 主界面走 HyperOS Rust/Flutter 启动模型，不完全等同普通 zygote Java app。
+- 早期日志显示普通 Java/Xposed 链路能影响部分配置，但不能完全接管最终 Flutter 文本。
+- 如果 native 注入时机晚于 `libhyper_os_flutter.so` 初始化，需要额外处理已加载库和 paragraph cache。
+
+适用价值：
+
+- 可作为辅助探针。
+- 不建议替代当前 RustProcess sibling proxy 主线。
+
+## 替代方案 4：ptrace / injector 动态注入
+
+做法：目标 app 启动后，用 root/ptrace 或其他 injector 把 DPIS native so 注入进 Gallery 进程。
+
+结论：能绕开文件落地，但复杂度和风险更高。
+
+优点：
+
+- 理论上不需要修改目标应用安装目录。
+- 可以在运行时更新注入逻辑。
+
+问题：
+
+- 需要维护额外 native injector。
+- 受 SELinux、ptrace 限制、进程时机、Android 版本差异影响。
+- 失败模式复杂，容易导致目标进程崩溃。
+- 仍要解决 linker namespace 和依赖库可见性。
+
+当前判断：不适合当前阶段。
+
+## 替代方案 5：替换原始 `libapp_gallery.so`
+
+做法：直接改名/替换 Gallery 原始 Rust binary，把 DPIS proxy 伪装成原始 so。
+
+结论：不建议。
+
+风险：
+
+- 破坏目标应用原始文件，回滚成本高。
+- 目标应用更新、完整性校验、路径变化都会放大风险。
+- 一旦 proxy 失败，Gallery 可能完全无法启动。
+- 比新增 sibling `libdpis_native.so` 更侵入。
+
+当前判断：禁止作为主线。
+
+## 替代方案 6：把 native 逻辑尽量配置化
+
+做法：减少以后修改 `dpis_native.cpp` 的次数，把更多行为改成 property/file 配置：
+
+- 字体百分比。
+- 是否启用 pushStyle。
+- 是否启用某些实验 hook。
+- 目标包策略。
+- 日志预算。
+
+结论：推荐作为中期优化，但不能替代首次部署 proxy。
+
+优点：
+
+- 一旦目标目录里的 proxy 足够通用，后续大部分调参不需要再复制 so。
+- 可以降低“改 native 后必须同步目标目录文件”的频率。
+
+限制：
+
+- 如果 hook 入口、trampoline、ABI 处理、offset 解析有变化，仍要更新 native so。
+- 旧 proxy 不会自动拥有新配置能力。
+
+当前状态：已经开始采用，例如 `debug.dpis.forcefont.<hash>`。
+
+## 替代方案 7：动态 offset / 签名扫描
+
+做法：native proxy 不再依赖固定 offset，而是扫描 `libhyper_os_flutter.so` 中的签名或符号特征定位 hook 点。
+
+结论：可提升跨版本稳定性，但仍需要 proxy 文件本身部署到目标目录。
+
+优点：
+
+- Gallery 更新后不一定需要重新编译 offset。
+- 可降低崩溃和无效 hook 的概率。
+
+问题：
+
+- 签名扫描实现复杂。
+- 误匹配风险高。
+- 不解决“目标进程要加载新版 proxy”的问题。
+
+当前判断：后续可做，但不是替代 sibling proxy 更新的方案。
+
+## 结论
+
+目前唯一确定、已验证、可解释的 native 代码更新方式是：更新目标应用 native 目录中的 sibling `libdpis_native.so`。
+
+但需要区分两类变更：
+
+- 只改配置值：用 `debug.dpis.forcefont.<hash>` 等运行时配置即可，不需要复制 so。
+- 改 native 代码：必须更新目标目录里的 sibling proxy，否则目标应用继续运行旧 native 逻辑。
+
+因此，后续 DPIS 应该把 sibling proxy 更新做成显式功能，而不是隐藏行为：检测、提示、复制、校验、回滚，全流程可见。

--- a/docs/hyperos-native-proxy-alternatives.md
+++ b/docs/hyperos-native-proxy-alternatives.md
@@ -192,3 +192,11 @@
 - 改 native 代码：必须更新目标目录里的 sibling proxy，否则目标应用继续运行旧 native 逻辑。
 
 因此，后续 DPIS 应该把 sibling proxy 更新做成显式功能，而不是隐藏行为：检测、提示、复制、校验、回滚，全流程可见。
+
+
+## Current Decision
+
+- Keep sibling native proxy as the supported path.
+- Do not keep the external-path or `LD_PRELOAD` experiment branches in normal hook code.
+- Keep runtime system properties for repeated value updates after the proxy path is prepared.
+- Keep detailed experiment logs out of active docs; archive them only when they are still useful for future research.


### PR DESCRIPTION
Refs (#33, #38)

增加 HyperOS Rust/Flutter 类应用的 DP/字体缩放支持，目标是让普通 Java 应用的既有 DP/字体伪装/替换链路保持不变，同时为 HyperOS native/Rust/Flutter 应用提供隔离的兼容路径。

## 当前实现

- HyperOS native proxy 候选检测按应用特性判断，而不是简单按 Gallery/Weather 白名单：
  - `hyperos_package`
  - `hyperos_app_lib_name`
  - `hyperos_application_entry`
- `system_server` 中 hook `android.os.RustProcessImpl.startRustProcess`，将目标 Rust binary 重定向到目标应用 native 目录下的 sibling `libdpis_native.so`。
- `libdpis_native.so` 作为 native proxy：
  - 优先从 env 读取 `DPIS_RUST_BINARY` 并加载原始 Rust so；
  - fallback 到 Weather sibling 原始库 / `debug.dpis.rustbin.<hash>`；
  - 转发 `app_entry_point`，保证目标应用继续正常启动。
- 字体倍率优先级：
  - `debug.dpis.forcefont.<hash>`
  - `debug.dpis.forcefont`
  - env / cmdline `DPIS_FONT_SCALE_PERCENT`
  - `debug.dpis.font.<hash>`
- Gallery 等 HyperOS Flutter 文本主要走 `libhyper_os_flutter.so` 的 paragraph hook。
- Weather 额外有 `com.miui.weather2` 专用的 `Configuration_get_font_scale` GOT hook；当前实测 GOT slot 指向 `libhyper_os_app_public.so` 中的同名符号。

## native proxy 部署

- DPIS APK 自带当前版本的 `libdpis_native.so`。
- 保存/重启 HyperOS native 候选应用时，会准备目标 native 目录中的 `libdpis_native.so`：
  - 先创建目标占位文件；
  - 先设置目标文件 metadata；
  - 再执行 `mount -o bind`；
  - bind 失败则 copy fallback；
  - 输出 `dpis_proxy_apply=bind` 或 `dpis_proxy_apply=copy` 便于排障。
- 注意：文件 bind 成功后不能再对 target 做 `chown/chmod/chcon`，否则会改到 DPIS 源 so 的 inode。

## 运行时与重启边界

- 只改 DP/字体数值：通常发布运行时属性并重启目标应用即可。
- 改 native proxy 或 RustProcess/system_server hook：覆盖安装 DPIS APK 不会让已运行的 `system_server` 自动加载新版代码，建议重启设备。
- APK 更新后旧 bind mount 可能指向已删除的旧 DPIS so，所以重启 HyperOS native 候选应用前会重新 prepare proxy。

## 近期验证

- Gallery：paragraph hook 可读取 `debug.dpis.forcefont.<hash>` 并按目标倍率工作。
- Weather：设备日志验证 `Configuration_get_font_scale GOT hook installed`，并返回 `value=3.000000` 对应 300%。
- 普通 Java 应用：仍走原有 DP/字体伪装/替换链路，HyperOS native 逻辑不参与。

## 验证命令

- `./gradlew :app:testDebugUnitTest`
- `./gradlew :app:assembleDebug`