### PR TITLE
fix: complete viewport override path on API 101/100

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -29,5 +29,8 @@ Thumbs.db
 /startup*.log
 /xhh-*.txt
 /dpis-check.txt
+/af.db
+/.debug-*.xml
+/.debug-smoke-*/
 
 /archive/

--- a/.gitignore
+++ b/.gitignore
@@ -29,8 +29,5 @@ Thumbs.db
 /startup*.log
 /xhh-*.txt
 /dpis-check.txt
-/af.db
-/.debug-*.xml
-/.debug-smoke-*/
 
 /archive/

--- a/AGENTS.md
+++ b/AGENTS.md
@@ -54,6 +54,25 @@
 - Group debug-only rows with their own dividers so release layouts keep static separators.
 - Before release-related commits, explicitly decide whether to remove or keep debug-only entries.
 
+## Runtime Debug Automation
+- Autofish may be used as an auxiliary Android automation channel for real-device
+  DPIS validation. It is for launching apps, coordinate taps/swipes, screenshots,
+  top-activity checks, and repeatable visual comparisons.
+- Do not treat Autofish accessibility trees as authoritative for apps with limited
+  accessibility exposure. These apps may expose only system/status/sidebar nodes,
+  so missing in-app text or tab labels in Autofish output does not prove the UI is
+  absent or unmodified.
+- For DPIS behavior claims, pair Autofish evidence with DPIS/LSPosed logs,
+  `dumpsys activity`, or app-process resource metrics. Autofish can confirm what
+  is visible and where to tap; it cannot confirm `Configuration`, `ResourcesImpl`,
+  `DisplayMetrics`, or system_server mutation state by itself.
+- Keep Autofish connection data local. Use `af config set remote.url ...` and
+  `af config set remote.token ...` on the agent machine, but do not commit tokens,
+  `af.db`, generated screenshots, or `.debug-*` evidence directories.
+- Current useful pattern for issue-style validation:
+  configure DPIS through the debug-only config entrypoint, use Autofish to launch
+  and navigate the target app, then collect screenshots plus adb/LSPosed logs.
+
 ## Gradle Task Detection
 - Build scripts must not infer release tasks by scanning arbitrary Gradle arguments such as `--tests`.
 - Release signing checks should only trigger for actual release task names.

--- a/app/src/compat100/java/com/dpis/module/Compat100LegacyModuleHook.java
+++ b/app/src/compat100/java/com/dpis/module/Compat100LegacyModuleHook.java
@@ -153,9 +153,12 @@ public final class Compat100LegacyModuleHook implements IXposedHookLoadPackage, 
                     resourcesManagerClass, packageName, store);
             int createHookCount = installResourceCreationHooks(
                     resourcesManagerClass, packageName, store);
+            int keyHookCount = installResourcesKeyHooks(
+                    resourcesManagerClass, packageName, store);
             compatDebugLog("compat100 legacy ResourcesManager hook ready"
                     + " (activityHooks=" + activityHookCount
-                    + ", createHooks=" + createHookCount + ")");
+                    + ", createHooks=" + createHookCount
+                    + ", keyHooks=" + keyHookCount + ")");
         } catch (Throwable throwable) {
             RESOURCES_MANAGER_HOOKED.set(false);
             compatErrorLog("compat100 legacy ResourcesManager hook failed: "
@@ -220,6 +223,34 @@ public final class Compat100LegacyModuleHook implements IXposedHookLoadPackage, 
         return hookedCount;
     }
 
+    private static int installResourcesKeyHooks(Class<?> resourcesManagerClass,
+                                                String packageName,
+                                                DpiConfigStore store) {
+        int hookedCount = 0;
+        Set<Method> hookedMethods = new HashSet<>();
+        for (Method method : resourcesManagerClass.getDeclaredMethods()) {
+            String methodName = method.getName();
+            if (!"createResourcesImpl".equals(methodName)
+                    || !hasResourcesKeyFirstArg(method)
+                    || !hookedMethods.add(method)) {
+                continue;
+            }
+            XposedBridge.hookMethod(method, new XC_MethodHook() {
+                @Override
+                protected void beforeHookedMethod(MethodHookParam param) {
+                    ResourcesManagerHookInstaller.maybeApplyKeyOverride(
+                            param.thisObject,
+                            param.args[0],
+                            store,
+                            packageName,
+                            "Compat100LegacyResourcesManagerKey(" + methodName + ")");
+                }
+            });
+            hookedCount++;
+        }
+        return hookedCount;
+    }
+
     private static int findConfigurationArgIndex(Method method) {
         Class<?>[] parameterTypes = method.getParameterTypes();
         for (int i = 0; i < parameterTypes.length; i++) {
@@ -235,6 +266,12 @@ public final class Compat100LegacyModuleHook implements IXposedHookLoadPackage, 
                 && (methodName.contains("createResources")
                 || methodName.contains("getOrCreateResources")
                 || methodName.contains("createBaseTokenResources"));
+    }
+
+    private static boolean hasResourcesKeyFirstArg(Method method) {
+        Class<?>[] parameterTypes = method.getParameterTypes();
+        return parameterTypes.length > 0
+                && "android.content.res.ResourcesKey".equals(parameterTypes[0].getName());
     }
 
     private static void installResourcesReadHooks(String packageName, DpiConfigStore store) {

--- a/app/src/debug/AndroidManifest.xml
+++ b/app/src/debug/AndroidManifest.xml
@@ -1,0 +1,22 @@
+<?xml version="1.0" encoding="utf-8"?>
+<manifest xmlns:android="http://schemas.android.com/apk/res/android">
+
+    <application>
+        <activity
+            android:name=".DebugConfigActivity"
+            android:excludeFromRecents="true"
+            android:exported="true"
+            android:finishOnTaskLaunch="true"
+            android:noHistory="true"
+            android:theme="@style/Theme.Dpis.Ingest" />
+
+        <receiver
+            android:name=".DebugConfigBroadcastReceiver"
+            android:enabled="true"
+            android:exported="true">
+            <intent-filter>
+                <action android:name="io.github.kwensiu.dpis.DEBUG_SET_PACKAGE_CONFIG" />
+            </intent-filter>
+        </receiver>
+    </application>
+</manifest>

--- a/app/src/debug/java/com/dpis/module/DebugConfigActivity.java
+++ b/app/src/debug/java/com/dpis/module/DebugConfigActivity.java
@@ -1,0 +1,14 @@
+package com.dpis.module;
+
+import android.app.Activity;
+import android.os.Bundle;
+
+public final class DebugConfigActivity extends Activity {
+    @Override
+    protected void onCreate(Bundle savedInstanceState) {
+        super.onCreate(savedInstanceState);
+        DebugConfigApplier.apply(this, getIntent(), false);
+        finish();
+        overridePendingTransition(0, 0);
+    }
+}

--- a/app/src/debug/java/com/dpis/module/DebugConfigApplier.java
+++ b/app/src/debug/java/com/dpis/module/DebugConfigApplier.java
@@ -19,6 +19,7 @@ final class DebugConfigApplier {
     private static final String EXTRA_RESTART = "restart";
     private static final String EXTRA_SAFE_MODE = "system_server_safe_mode";
     private static final String EXTRA_LOG_ENABLED = "log_enabled";
+    private static final String EXTRA_FONT_DEBUG_OVERLAY_ENABLED = "font_debug_overlay_enabled";
 
     private DebugConfigApplier() {
     }
@@ -79,6 +80,10 @@ final class DebugConfigApplier {
             saved &= store.setGlobalLogEnabled(loggingEnabled);
             DpisLog.setLoggingEnabled(loggingEnabled);
         }
+        if (intent.hasExtra(EXTRA_FONT_DEBUG_OVERLAY_ENABLED)) {
+            saved &= store.setFontDebugOverlayEnabled(
+                    intent.getBooleanExtra(EXTRA_FONT_DEBUG_OVERLAY_ENABLED, false));
+        }
 
         boolean restart = intent.getBooleanExtra(EXTRA_RESTART, false);
         if (restart) {
@@ -92,6 +97,7 @@ final class DebugConfigApplier {
                 + ", fontMode=" + store.getTargetFontApplyMode(packageName)
                 + ", systemServerSafeMode=" + store.isSystemServerSafeModeEnabled()
                 + ", logEnabled=" + store.isGlobalLogEnabled()
+                + ", fontDebugOverlayEnabled=" + store.isFontDebugOverlayEnabled()
                 + ", restart=" + restart);
     }
 

--- a/app/src/debug/java/com/dpis/module/DebugConfigApplier.java
+++ b/app/src/debug/java/com/dpis/module/DebugConfigApplier.java
@@ -1,0 +1,138 @@
+package com.dpis.module;
+
+import android.content.Context;
+import android.content.Intent;
+import android.util.Log;
+
+import java.io.IOException;
+
+final class DebugConfigApplier {
+    static final String ACTION_SET_PACKAGE_CONFIG =
+            "io.github.kwensiu.dpis.DEBUG_SET_PACKAGE_CONFIG";
+    static final String TAG = "DPIS_DEBUG_CONFIG";
+
+    private static final String EXTRA_PACKAGE = "package";
+    private static final String EXTRA_VIEWPORT_WIDTH_DP = "viewport_width_dp";
+    private static final String EXTRA_VIEWPORT_MODE = "viewport_mode";
+    private static final String EXTRA_FONT_SCALE_PERCENT = "font_scale_percent";
+    private static final String EXTRA_FONT_MODE = "font_mode";
+    private static final String EXTRA_RESTART = "restart";
+    private static final String EXTRA_SAFE_MODE = "system_server_safe_mode";
+    private static final String EXTRA_LOG_ENABLED = "log_enabled";
+
+    private DebugConfigApplier() {
+    }
+
+    static void apply(Context context, Intent intent, boolean requireActionMatch) {
+        if (!BuildConfig.DEBUG) {
+            return;
+        }
+        if (intent == null) {
+            return;
+        }
+        if (requireActionMatch && !ACTION_SET_PACKAGE_CONFIG.equals(intent.getAction())) {
+            return;
+        }
+        String packageName = intent.getStringExtra(EXTRA_PACKAGE);
+        if (packageName == null || packageName.isBlank()) {
+            Log.w(TAG, "ignored: missing package");
+            return;
+        }
+        DpiConfigStore store = DpisApplication.getConfigStore();
+        boolean saved = true;
+
+        if (intent.hasExtra(EXTRA_VIEWPORT_WIDTH_DP)) {
+            int widthDp = intent.getIntExtra(EXTRA_VIEWPORT_WIDTH_DP, 0);
+            String mode = intent.getStringExtra(EXTRA_VIEWPORT_MODE);
+            String normalizedMode = ViewportApplyMode.normalize(mode);
+            if (widthDp > 0 && ViewportApplyMode.isEnabled(normalizedMode)) {
+                saved &= store.setTargetViewportWidthDp(packageName, widthDp);
+                saved &= store.setTargetViewportApplyMode(packageName, normalizedMode);
+                ViewportPropertySyncer.publishTargetAsync(packageName, widthDp, normalizedMode);
+            } else {
+                saved &= store.clearTargetViewportWidthDp(packageName);
+                ViewportPropertySyncer.clearTargetAsync(packageName);
+            }
+        }
+
+        if (intent.hasExtra(EXTRA_FONT_SCALE_PERCENT)) {
+            int fontScalePercent = intent.getIntExtra(EXTRA_FONT_SCALE_PERCENT, 0);
+            String mode = intent.getStringExtra(EXTRA_FONT_MODE);
+            String normalizedMode = FontApplyMode.normalize(mode);
+            if (fontScalePercent > 0 && FontApplyMode.isEnabled(normalizedMode)) {
+                saved &= store.setTargetFontScalePercent(packageName, fontScalePercent);
+                saved &= store.setTargetFontApplyMode(packageName, normalizedMode);
+                FontRuntimePropertySyncer.publishTargetAsync(packageName, fontScalePercent,
+                        normalizedMode, store.isHyperOsFlutterFontHookEnabled());
+            } else {
+                saved &= store.clearTargetFontScalePercent(packageName);
+                FontRuntimePropertySyncer.clearTargetAsync(packageName);
+            }
+        }
+
+        if (intent.hasExtra(EXTRA_SAFE_MODE)) {
+            saved &= store.setSystemServerSafeModeEnabled(
+                    intent.getBooleanExtra(EXTRA_SAFE_MODE, true));
+        }
+        if (intent.hasExtra(EXTRA_LOG_ENABLED)) {
+            boolean loggingEnabled = intent.getBooleanExtra(EXTRA_LOG_ENABLED, false);
+            saved &= store.setGlobalLogEnabled(loggingEnabled);
+            DpisLog.setLoggingEnabled(loggingEnabled);
+        }
+
+        boolean restart = intent.getBooleanExtra(EXTRA_RESTART, false);
+        if (restart) {
+            restartTargetAsync(packageName);
+        }
+        Log.i(TAG, "package=" + packageName
+                + ", saved=" + saved
+                + ", viewportWidthDp=" + store.getTargetViewportWidthDp(packageName)
+                + ", viewportMode=" + store.getTargetViewportApplyMode(packageName)
+                + ", fontScalePercent=" + store.getTargetFontScalePercent(packageName)
+                + ", fontMode=" + store.getTargetFontApplyMode(packageName)
+                + ", systemServerSafeMode=" + store.isSystemServerSafeModeEnabled()
+                + ", logEnabled=" + store.isGlobalLogEnabled()
+                + ", restart=" + restart);
+    }
+
+    private static void restartTargetAsync(String packageName) {
+        Thread thread = new Thread(() -> {
+            sleepQuietly(400L);
+            runRootCommand("am force-stop " + shellQuote(packageName)
+                    + "; monkey -p " + shellQuote(packageName)
+                    + " -c android.intent.category.LAUNCHER 1");
+        }, "DPIS-debug-config-restarter");
+        thread.setDaemon(true);
+        thread.start();
+    }
+
+    private static void sleepQuietly(long millis) {
+        try {
+            Thread.sleep(millis);
+        } catch (InterruptedException ignored) {
+            Thread.currentThread().interrupt();
+        }
+    }
+
+    private static void runRootCommand(String command) {
+        Process process = null;
+        try {
+            process = Runtime.getRuntime().exec(new String[]{"su", "-c", command});
+            process.waitFor();
+        } catch (IOException ignored) {
+        } catch (InterruptedException ignored) {
+            Thread.currentThread().interrupt();
+        } finally {
+            if (process != null) {
+                process.destroy();
+            }
+        }
+    }
+
+    private static String shellQuote(String value) {
+        if (value == null || value.isEmpty()) {
+            return "''";
+        }
+        return "'" + value.replace("'", "'\\''") + "'";
+    }
+}

--- a/app/src/debug/java/com/dpis/module/DebugConfigBroadcastReceiver.java
+++ b/app/src/debug/java/com/dpis/module/DebugConfigBroadcastReceiver.java
@@ -1,0 +1,15 @@
+package com.dpis.module;
+
+import android.content.BroadcastReceiver;
+import android.content.Context;
+import android.content.Intent;
+
+public final class DebugConfigBroadcastReceiver extends BroadcastReceiver {
+    static final String ACTION_SET_PACKAGE_CONFIG =
+            DebugConfigApplier.ACTION_SET_PACKAGE_CONFIG;
+
+    @Override
+    public void onReceive(Context context, Intent intent) {
+        DebugConfigApplier.apply(context, intent, true);
+    }
+}

--- a/app/src/main/java/com/dpis/module/FontDebugStatsTransport.java
+++ b/app/src/main/java/com/dpis/module/FontDebugStatsTransport.java
@@ -31,6 +31,11 @@ final class FontDebugStatsTransport {
         if (extras == null || extras.isEmpty()) {
             return;
         }
+        // Target app contexts cannot start non-exported module components.
+        if (!isModuleContext(context)) {
+            FontDebugStatsFileBridge.write(context, extras);
+            return;
+        }
         SharedPreferences preferences = remotePreferences;
         if (preferences != null) {
             try {
@@ -80,6 +85,10 @@ final class FontDebugStatsTransport {
             DpisLog.e("font debug ingest activity update failed", throwable);
         }
         FontDebugStatsFileBridge.write(context, extras);
+    }
+
+    private static boolean isModuleContext(Context context) {
+        return context != null && BuildConfig.APPLICATION_ID.equals(context.getPackageName());
     }
 
     private static Uri buildUri() {

--- a/app/src/main/java/com/dpis/module/ResourcesImplHookInstaller.java
+++ b/app/src/main/java/com/dpis/module/ResourcesImplHookInstaller.java
@@ -65,7 +65,7 @@ final class ResourcesImplHookInstaller {
         if (result == null) {
             FontScaleOverride.applyScaledDensity(metrics, config);
             logIfChanged(packageName + ":observe",
-                    "DPIS_FONT ResourcesImpl observe: widthDp=" + originalWidthDp
+                    "DPIS_VIEWPORT ResourcesImpl observe: widthDp=" + originalWidthDp
                             + ", heightDp=" + originalHeightDp
                             + ", smallestWidthDp=" + originalSmallestWidthDp
                             + ", densityDpi=" + originalDensityDpi
@@ -120,7 +120,7 @@ final class ResourcesImplHookInstaller {
                     metrics.heightPixels = stableResult.heightPx;
                 }
                 logIfChanged(packageName + ":stable-target",
-                        "DPIS_FONT ResourcesImpl stable target: widthDp="
+                        "DPIS_VIEWPORT ResourcesImpl stable target: widthDp="
                                 + config.screenWidthDp
                                 + ", heightDp=" + config.screenHeightDp
                                 + ", smallestWidthDp=" + config.smallestScreenWidthDp
@@ -136,7 +136,7 @@ final class ResourcesImplHookInstaller {
             }
             FontScaleOverride.applyScaledDensity(metrics, config);
             logIfChanged(packageName + ":observe",
-                    "DPIS_FONT ResourcesImpl observe: widthDp=" + originalWidthDp
+                    "DPIS_VIEWPORT ResourcesImpl observe: widthDp=" + originalWidthDp
                             + ", heightDp=" + originalHeightDp
                             + ", smallestWidthDp=" + originalSmallestWidthDp
                             + ", densityDpi=" + originalDensityDpi
@@ -159,9 +159,9 @@ final class ResourcesImplHookInstaller {
                 metrics.heightPixels = applied.heightPx;
             }
         }
-        String modeLabel = applyToConfiguration ? "emulation" : "replace";
+        String modeLabel = applyToConfiguration ? "config" : "metrics";
         logIfChanged(packageName + ":override",
-                "DPIS_FONT ResourcesImpl (" + modeLabel + ") override: widthDp "
+                "DPIS_VIEWPORT ResourcesImpl (" + modeLabel + ") override: widthDp "
                         + originalWidthDp + " -> " + result.widthDp
                         + ", heightDp " + originalHeightDp + " -> " + result.heightDp
                         + ", smallestWidthDp " + originalSmallestWidthDp + " -> "

--- a/app/src/main/java/com/dpis/module/ResourcesImplHookInstaller.java
+++ b/app/src/main/java/com/dpis/module/ResourcesImplHookInstaller.java
@@ -91,9 +91,8 @@ final class ResourcesImplHookInstaller {
                 sourceWidthPx,
                 sourceHeightPx,
                 result.smallestWidthDp);
-        if (sharedResult != null) {
-            VirtualDisplayState.set(sharedResult);
-        }
+        VirtualDisplayState.setUnlessDerivedFromTargetConfig(
+                sharedResult, originalSmallestWidthDp, targetViewportWidth);
         String viewportMode = ViewportModePolicy.resolve(store, packageName);
         ViewportDebugReporter.report(
                 store,
@@ -106,6 +105,35 @@ final class ResourcesImplHookInstaller {
                 sharedResult,
                 applyToConfiguration);
         if (!needsViewportUpdate) {
+            VirtualDisplayOverride.Result stableResult =
+                    VirtualDisplayState.getStableTargetResult(
+                            originalSmallestWidthDp, targetViewportWidth);
+            if (stableResult != null && stableResult.densityDpi > 0
+                    && config.densityDpi != stableResult.densityDpi) {
+                config.densityDpi = stableResult.densityDpi;
+                if (metrics != null) {
+                    metrics.densityDpi = stableResult.densityDpi;
+                    metrics.density = DensityOverride.densityFromDpi(stableResult.densityDpi);
+                    metrics.scaledDensity = DensityOverride.scaledDensityFrom(
+                            stableResult.densityDpi, config.fontScale);
+                    metrics.widthPixels = stableResult.widthPx;
+                    metrics.heightPixels = stableResult.heightPx;
+                }
+                logIfChanged(packageName + ":stable-target",
+                        "DPIS_FONT ResourcesImpl stable target: widthDp="
+                                + config.screenWidthDp
+                                + ", heightDp=" + config.screenHeightDp
+                                + ", smallestWidthDp=" + config.smallestScreenWidthDp
+                                + ", densityDpi " + originalDensityDpi
+                                + " -> " + config.densityDpi
+                                + ", metricsDensityDpi="
+                                + (metrics != null ? metrics.densityDpi : -1)
+                                + ", metricsWidthPx="
+                                + (metrics != null ? metrics.widthPixels : -1)
+                                + ", metricsHeightPx="
+                                + (metrics != null ? metrics.heightPixels : -1));
+                return;
+            }
             FontScaleOverride.applyScaledDensity(metrics, config);
             logIfChanged(packageName + ":observe",
                     "DPIS_FONT ResourcesImpl observe: widthDp=" + originalWidthDp

--- a/app/src/main/java/com/dpis/module/ResourcesManagerHookInstaller.java
+++ b/app/src/main/java/com/dpis/module/ResourcesManagerHookInstaller.java
@@ -147,19 +147,20 @@ final class ResourcesManagerHookInstaller {
         if (!(override instanceof Configuration overrideConfig)) {
             return;
         }
-        if (!isEffectivelyEmpty(overrideConfig)) {
-            return;
-        }
         Configuration baseConfig = readResourcesManagerConfiguration(resourcesManager);
         if (baseConfig == null) {
             return;
         }
+        if (!shouldReplaceResourcesKeyOverride(overrideConfig, baseConfig)) {
+            return;
+        }
         Configuration targetConfig = new Configuration();
-        copyViewportConfiguration(baseConfig, targetConfig);
-        targetConfig.fontScale = baseConfig.fontScale;
+        Configuration sourceConfig = isEffectivelyEmpty(overrideConfig) ? baseConfig : overrideConfig;
+        copyViewportConfiguration(sourceConfig, targetConfig);
+        targetConfig.fontScale = sourceConfig.fontScale;
         applyResourceOverrides(targetConfig, store, packageName,
                 "ResourcesManagerKey(" + sourceTag + ")");
-        if (!hasViewportOverride(targetConfig, baseConfig)) {
+        if (!hasViewportOverride(targetConfig, sourceConfig)) {
             return;
         }
         copyViewportConfiguration(targetConfig, overrideConfig);
@@ -185,6 +186,32 @@ final class ResourcesManagerHookInstaller {
                 && config.screenHeightDp <= 0
                 && config.smallestScreenWidthDp <= 0
                 && config.densityDpi <= 0;
+    }
+
+    private static boolean shouldReplaceResourcesKeyOverride(Configuration overrideConfig,
+                                                            Configuration baseConfig) {
+        if (overrideConfig == null || baseConfig == null) {
+            return false;
+        }
+        if (isEffectivelyEmpty(overrideConfig)) {
+            return true;
+        }
+        boolean hasViewportFields = overrideConfig.screenWidthDp > 0
+                || overrideConfig.screenHeightDp > 0
+                || overrideConfig.smallestScreenWidthDp > 0
+                || overrideConfig.densityDpi > 0;
+        if (!hasViewportFields) {
+            return true;
+        }
+        boolean sameBounds = (overrideConfig.screenWidthDp <= 0
+                || overrideConfig.screenWidthDp == baseConfig.screenWidthDp)
+                && (overrideConfig.screenHeightDp <= 0
+                || overrideConfig.screenHeightDp == baseConfig.screenHeightDp)
+                && (overrideConfig.smallestScreenWidthDp <= 0
+                || overrideConfig.smallestScreenWidthDp == baseConfig.smallestScreenWidthDp);
+        boolean sameDensity = overrideConfig.densityDpi <= 0
+                || overrideConfig.densityDpi == baseConfig.densityDpi;
+        return sameBounds && sameDensity;
     }
 
     private static boolean hasViewportOverride(Configuration target, Configuration source) {

--- a/app/src/main/java/com/dpis/module/ResourcesManagerHookInstaller.java
+++ b/app/src/main/java/com/dpis/module/ResourcesManagerHookInstaller.java
@@ -161,9 +161,8 @@ final class ResourcesManagerHookInstaller {
                         ? Math.round(originalHeightDp * (originalDensityDpi / 160.0f))
                         : result.heightDp,
                 result.smallestWidthDp);
-        if (sharedResult != null) {
-            VirtualDisplayState.set(sharedResult);
-        }
+        VirtualDisplayState.setUnlessDerivedFromTargetConfig(
+                sharedResult, originalSmallestWidthDp, targetViewportWidth);
         boolean applyToConfiguration = ViewportModePolicy.shouldApplyConfigurationOverride(
                 store, packageName);
         if (result.widthDp == originalWidthDp
@@ -171,6 +170,25 @@ final class ResourcesManagerHookInstaller {
                 && result.smallestWidthDp == originalSmallestWidthDp
                 && result.densityDpi == originalDensityDpi
                 && !fontScale.changed) {
+            VirtualDisplayOverride.Result stableResult =
+                    VirtualDisplayState.getStableTargetResult(
+                            originalSmallestWidthDp, targetViewportWidth);
+            if (stableResult != null && stableResult.densityDpi > 0
+                    && config.densityDpi != stableResult.densityDpi) {
+                config.densityDpi = stableResult.densityDpi;
+                String message = "DPIS_FONT " + sourceTag
+                        + " stable target: widthDp " + originalWidthDp
+                        + " -> " + config.screenWidthDp
+                        + ", heightDp " + originalHeightDp
+                        + " -> " + config.screenHeightDp
+                        + ", smallestWidthDp " + originalSmallestWidthDp
+                        + " -> " + config.smallestScreenWidthDp
+                        + ", densityDpi " + originalDensityDpi
+                        + " -> " + config.densityDpi
+                        + ", fontScale " + fontScale.original
+                        + " -> " + config.fontScale;
+                logIfChanged(packageName + ":" + sourceTag + ":stable-target", message);
+            }
             return;
         }
         if (applyToConfiguration

--- a/app/src/main/java/com/dpis/module/ResourcesManagerHookInstaller.java
+++ b/app/src/main/java/com/dpis/module/ResourcesManagerHookInstaller.java
@@ -2,7 +2,6 @@ package com.dpis.module;
 
 import android.annotation.SuppressLint;
 import android.content.res.Configuration;
-import android.util.DisplayMetrics;
 
 import java.lang.reflect.Field;
 import java.lang.reflect.Method;
@@ -10,15 +9,12 @@ import java.util.HashSet;
 import java.util.Map;
 import java.util.Set;
 import java.util.concurrent.ConcurrentHashMap;
-import java.util.concurrent.atomic.AtomicInteger;
 
 import io.github.libxposed.api.XposedInterface;
 
 final class ResourcesManagerHookInstaller {
     private static volatile boolean hookInstalled;
     private static final Map<String, String> LAST_MESSAGES = new ConcurrentHashMap<>();
-    private static final int MAX_KEY_PROBE_LOGS = 24;
-    private static final AtomicInteger KEY_PROBE_LOG_COUNT = new AtomicInteger();
 
     private ResourcesManagerHookInstaller() {
     }
@@ -129,9 +125,7 @@ final class ResourcesManagerHookInstaller {
                         Object key = chain.getArg(0);
                         maybeApplyKeyOverride(
                                 chain.getThisObject(), key, store, packageName, methodName);
-                        Object result = chain.proceed();
-                        logResourcesKeyProbe(packageName, methodName, key, result);
-                        return result;
+                        return chain.proceed();
                     });
             hookedCount++;
         }
@@ -289,7 +283,7 @@ final class ResourcesManagerHookInstaller {
             if (stableResult != null && stableResult.densityDpi > 0
                     && config.densityDpi != stableResult.densityDpi) {
                 config.densityDpi = stableResult.densityDpi;
-                String message = "DPIS_FONT " + sourceTag
+                String message = "DPIS_VIEWPORT " + sourceTag
                         + " stable target: widthDp " + originalWidthDp
                         + " -> " + config.screenWidthDp
                         + ", heightDp " + originalHeightDp
@@ -311,8 +305,9 @@ final class ResourcesManagerHookInstaller {
                 || result.densityDpi != originalDensityDpi)) {
             ViewportOverride.apply(config, result);
         }
-        String modeLabel = applyToConfiguration ? "emulation" : "replace";
-        String message = "DPIS_FONT " + sourceTag + " (" + modeLabel + ") override: widthDp "
+        String modeLabel = applyToConfiguration ? "config" : "metrics";
+        String message = "DPIS_VIEWPORT " + sourceTag + " (" + modeLabel
+                + ") override: widthDp "
                 + originalWidthDp + " -> " + result.widthDp
                 + ", heightDp " + originalHeightDp + " -> " + result.heightDp
                 + ", smallestWidthDp " + originalSmallestWidthDp + " -> "
@@ -330,64 +325,6 @@ final class ResourcesManagerHookInstaller {
         }
     }
 
-    private static void logResourcesKeyProbe(String packageName,
-                                             String methodName,
-                                             Object key,
-                                             Object impl) {
-        if (KEY_PROBE_LOG_COUNT.incrementAndGet() > MAX_KEY_PROBE_LOGS) {
-            return;
-        }
-        DpisLog.i("ResourcesManager key probe(" + methodName + "): key="
-                + describeResourcesKey(key)
-                + ", impl=" + describeResourcesImpl(impl)
-                + appendCaller(packageName));
-    }
-
-    private static String describeResourcesKey(Object key) {
-        if (key == null) {
-            return "null";
-        }
-        int displayId = readIntField(key, "mDisplayId", Integer.MIN_VALUE);
-        Object override = readField(key, "mOverrideConfiguration");
-        return "id=" + System.identityHashCode(key)
-                + ", displayId=" + (displayId == Integer.MIN_VALUE ? "?" : displayId)
-                + ", override=" + describeConfiguration(override);
-    }
-
-    private static String describeResourcesImpl(Object impl) {
-        if (impl == null) {
-            return "null";
-        }
-        Object config = readField(impl, "mConfiguration");
-        Object metrics = readField(impl, "mMetrics");
-        return "id=" + System.identityHashCode(impl)
-                + ", config=" + describeConfiguration(config)
-                + ", metrics=" + (metrics instanceof DisplayMetrics displayMetrics
-                ? describeDisplayMetrics(displayMetrics) : String.valueOf(metrics));
-    }
-
-    private static String describeConfiguration(Object config) {
-        if (!(config instanceof Configuration configuration)) {
-            return String.valueOf(config);
-        }
-        return "config{widthDp=" + configuration.screenWidthDp
-                + ",heightDp=" + configuration.screenHeightDp
-                + ",smallestWidthDp=" + configuration.smallestScreenWidthDp
-                + ",densityDpi=" + configuration.densityDpi
-                + ",fontScale=" + configuration.fontScale + "}";
-    }
-
-    private static String describeDisplayMetrics(DisplayMetrics metrics) {
-        if (metrics == null) {
-            return "null";
-        }
-        return "metrics{widthPx=" + metrics.widthPixels
-                + ",heightPx=" + metrics.heightPixels
-                + ",densityDpi=" + metrics.densityDpi
-                + ",density=" + metrics.density
-                + ",scaledDensity=" + metrics.scaledDensity + "}";
-    }
-
     private static Object readField(Object target, String fieldName) {
         if (target == null) {
             return null;
@@ -400,18 +337,4 @@ final class ResourcesManagerHookInstaller {
             return null;
         }
     }
-
-    private static int readIntField(Object target, String fieldName, int fallback) {
-        Object value = readField(target, fieldName);
-        return value instanceof Integer integer ? integer : fallback;
-    }
-
-    private static String appendCaller(String packageName) {
-        String caller = CallerTrace.capture(packageName);
-        if (caller == null) {
-            return "";
-        }
-        return ", caller=" + caller;
-    }
 }
-

--- a/app/src/main/java/com/dpis/module/ResourcesManagerHookInstaller.java
+++ b/app/src/main/java/com/dpis/module/ResourcesManagerHookInstaller.java
@@ -2,18 +2,23 @@ package com.dpis.module;
 
 import android.annotation.SuppressLint;
 import android.content.res.Configuration;
+import android.util.DisplayMetrics;
 
+import java.lang.reflect.Field;
 import java.lang.reflect.Method;
 import java.util.HashSet;
 import java.util.Map;
 import java.util.Set;
 import java.util.concurrent.ConcurrentHashMap;
+import java.util.concurrent.atomic.AtomicInteger;
 
 import io.github.libxposed.api.XposedInterface;
 
 final class ResourcesManagerHookInstaller {
     private static volatile boolean hookInstalled;
     private static final Map<String, String> LAST_MESSAGES = new ConcurrentHashMap<>();
+    private static final int MAX_KEY_PROBE_LOGS = 24;
+    private static final AtomicInteger KEY_PROBE_LOG_COUNT = new AtomicInteger();
 
     private ResourcesManagerHookInstaller() {
     }
@@ -55,8 +60,11 @@ final class ResourcesManagerHookInstaller {
 
             int createHookCount = installResourceCreationHooks(
                     xposed, resourcesManagerClass, packageName, store);
+            int keyHookCount = installResourcesKeyHooks(
+                    xposed, resourcesManagerClass, packageName, store);
             hookInstalled = true;
-            DpisLog.i("ResourcesManager hook ready (createHooks=" + createHookCount + ")");
+            DpisLog.i("ResourcesManager hook ready (createHooks=" + createHookCount
+                    + ", keyHooks=" + keyHookCount + ")");
         }
     }
 
@@ -100,6 +108,111 @@ final class ResourcesManagerHookInstaller {
             hookedCount++;
         }
         return hookedCount;
+    }
+
+    private static int installResourcesKeyHooks(XposedInterface xposed,
+                                                Class<?> resourcesManagerClass,
+                                                String packageName,
+                                                DpiConfigStore store) {
+        int hookedCount = 0;
+        Set<Method> hookedMethods = new HashSet<>();
+        for (Method method : resourcesManagerClass.getDeclaredMethods()) {
+            String methodName = method.getName();
+            if (!"createResourcesImpl".equals(methodName)
+                    || !hasResourcesKeyFirstArg(method)
+                    || !hookedMethods.add(method)) {
+                continue;
+            }
+            xposed.hook(method)
+                    .setExceptionMode(XposedInterface.ExceptionMode.PROTECTIVE)
+                    .intercept(chain -> {
+                        Object key = chain.getArg(0);
+                        maybeApplyKeyOverride(
+                                chain.getThisObject(), key, store, packageName, methodName);
+                        Object result = chain.proceed();
+                        logResourcesKeyProbe(packageName, methodName, key, result);
+                        return result;
+                    });
+            hookedCount++;
+        }
+        return hookedCount;
+    }
+
+    static void maybeApplyKeyOverride(Object resourcesManager,
+                                      Object key,
+                                      DpiConfigStore store,
+                                      String packageName,
+                                      String sourceTag) {
+        if (resourcesManager == null || key == null) {
+            return;
+        }
+        if (!ViewportModePolicy.shouldApplyConfigurationOverride(store, packageName)) {
+            return;
+        }
+        Object override = readField(key, "mOverrideConfiguration");
+        if (!(override instanceof Configuration overrideConfig)) {
+            return;
+        }
+        if (!isEffectivelyEmpty(overrideConfig)) {
+            return;
+        }
+        Configuration baseConfig = readResourcesManagerConfiguration(resourcesManager);
+        if (baseConfig == null) {
+            return;
+        }
+        Configuration targetConfig = new Configuration();
+        copyViewportConfiguration(baseConfig, targetConfig);
+        targetConfig.fontScale = baseConfig.fontScale;
+        applyResourceOverrides(targetConfig, store, packageName,
+                "ResourcesManagerKey(" + sourceTag + ")");
+        if (!hasViewportOverride(targetConfig, baseConfig)) {
+            return;
+        }
+        copyViewportConfiguration(targetConfig, overrideConfig);
+    }
+
+    private static Configuration readResourcesManagerConfiguration(Object resourcesManager) {
+        try {
+            Method method = resourcesManager.getClass().getDeclaredMethod("getConfiguration");
+            method.setAccessible(true);
+            Object result = method.invoke(resourcesManager);
+            if (result instanceof Configuration configuration) {
+                return configuration;
+            }
+        } catch (ReflectiveOperationException | RuntimeException ignored) {
+        }
+        Object config = readField(resourcesManager, "mResConfiguration");
+        return config instanceof Configuration configuration ? configuration : null;
+    }
+
+    private static boolean isEffectivelyEmpty(Configuration config) {
+        return config != null
+                && config.screenWidthDp <= 0
+                && config.screenHeightDp <= 0
+                && config.smallestScreenWidthDp <= 0
+                && config.densityDpi <= 0;
+    }
+
+    private static boolean hasViewportOverride(Configuration target, Configuration source) {
+        return target != null
+                && source != null
+                && (target.screenWidthDp != source.screenWidthDp
+                || target.screenHeightDp != source.screenHeightDp
+                || target.smallestScreenWidthDp != source.smallestScreenWidthDp
+                || target.densityDpi != source.densityDpi);
+    }
+
+    private static void copyViewportConfiguration(Configuration source, Configuration target) {
+        target.screenWidthDp = source.screenWidthDp;
+        target.screenHeightDp = source.screenHeightDp;
+        target.smallestScreenWidthDp = source.smallestScreenWidthDp;
+        target.densityDpi = source.densityDpi;
+    }
+
+    private static boolean hasResourcesKeyFirstArg(Method method) {
+        Class<?>[] parameterTypes = method.getParameterTypes();
+        return parameterTypes.length > 0
+                && "android.content.res.ResourcesKey".equals(parameterTypes[0].getName());
     }
 
     private static int findConfigurationArgIndex(Method method) {
@@ -215,6 +328,90 @@ final class ResourcesManagerHookInstaller {
         if (!message.equals(previous)) {
             DpisLog.i(message);
         }
+    }
+
+    private static void logResourcesKeyProbe(String packageName,
+                                             String methodName,
+                                             Object key,
+                                             Object impl) {
+        if (KEY_PROBE_LOG_COUNT.incrementAndGet() > MAX_KEY_PROBE_LOGS) {
+            return;
+        }
+        DpisLog.i("ResourcesManager key probe(" + methodName + "): key="
+                + describeResourcesKey(key)
+                + ", impl=" + describeResourcesImpl(impl)
+                + appendCaller(packageName));
+    }
+
+    private static String describeResourcesKey(Object key) {
+        if (key == null) {
+            return "null";
+        }
+        int displayId = readIntField(key, "mDisplayId", Integer.MIN_VALUE);
+        Object override = readField(key, "mOverrideConfiguration");
+        return "id=" + System.identityHashCode(key)
+                + ", displayId=" + (displayId == Integer.MIN_VALUE ? "?" : displayId)
+                + ", override=" + describeConfiguration(override);
+    }
+
+    private static String describeResourcesImpl(Object impl) {
+        if (impl == null) {
+            return "null";
+        }
+        Object config = readField(impl, "mConfiguration");
+        Object metrics = readField(impl, "mMetrics");
+        return "id=" + System.identityHashCode(impl)
+                + ", config=" + describeConfiguration(config)
+                + ", metrics=" + (metrics instanceof DisplayMetrics displayMetrics
+                ? describeDisplayMetrics(displayMetrics) : String.valueOf(metrics));
+    }
+
+    private static String describeConfiguration(Object config) {
+        if (!(config instanceof Configuration configuration)) {
+            return String.valueOf(config);
+        }
+        return "config{widthDp=" + configuration.screenWidthDp
+                + ",heightDp=" + configuration.screenHeightDp
+                + ",smallestWidthDp=" + configuration.smallestScreenWidthDp
+                + ",densityDpi=" + configuration.densityDpi
+                + ",fontScale=" + configuration.fontScale + "}";
+    }
+
+    private static String describeDisplayMetrics(DisplayMetrics metrics) {
+        if (metrics == null) {
+            return "null";
+        }
+        return "metrics{widthPx=" + metrics.widthPixels
+                + ",heightPx=" + metrics.heightPixels
+                + ",densityDpi=" + metrics.densityDpi
+                + ",density=" + metrics.density
+                + ",scaledDensity=" + metrics.scaledDensity + "}";
+    }
+
+    private static Object readField(Object target, String fieldName) {
+        if (target == null) {
+            return null;
+        }
+        try {
+            Field field = target.getClass().getDeclaredField(fieldName);
+            field.setAccessible(true);
+            return field.get(target);
+        } catch (ReflectiveOperationException | RuntimeException ignored) {
+            return null;
+        }
+    }
+
+    private static int readIntField(Object target, String fieldName, int fallback) {
+        Object value = readField(target, fieldName);
+        return value instanceof Integer integer ? integer : fallback;
+    }
+
+    private static String appendCaller(String packageName) {
+        String caller = CallerTrace.capture(packageName);
+        if (caller == null) {
+            return "";
+        }
+        return ", caller=" + caller;
     }
 }
 

--- a/app/src/main/java/com/dpis/module/ResourcesReadHookInstaller.java
+++ b/app/src/main/java/com/dpis/module/ResourcesReadHookInstaller.java
@@ -135,15 +135,30 @@ final class ResourcesReadHookInstaller {
                 Math.round((originalHeightDp > 0 ? originalHeightDp : result.heightDp)
                         * ((originalDensityDpi > 0 ? originalDensityDpi : result.densityDpi) / 160.0f)),
                 result.smallestWidthDp);
-        if (sharedResult != null) {
-            VirtualDisplayState.set(sharedResult);
-        }
+        VirtualDisplayState.setUnlessDerivedFromTargetConfig(
+                sharedResult, originalSmallestWidthDp, targetViewportWidth);
 
         if (result.widthDp == originalWidthDp
                 && result.heightDp == originalHeightDp
                 && result.smallestWidthDp == originalSmallestWidthDp
                 && result.densityDpi == originalDensityDpi
                 && !fontScale.changed) {
+            VirtualDisplayOverride.Result stableResult =
+                    VirtualDisplayState.getStableTargetResult(
+                            originalSmallestWidthDp, targetViewportWidth);
+            if (stableResult != null && stableResult.densityDpi > 0
+                    && config.densityDpi != stableResult.densityDpi) {
+                config.densityDpi = stableResult.densityDpi;
+                logIfChanged(packageName + ":" + sourceTag + ":stable-target",
+                        "DPIS_FONT " + sourceTag + " stable target: widthDp="
+                                + config.screenWidthDp
+                                + ", heightDp=" + config.screenHeightDp
+                                + ", smallestWidthDp=" + config.smallestScreenWidthDp
+                                + ", densityDpi " + originalDensityDpi
+                                + " -> " + config.densityDpi
+                                + ", fontScale " + fontScale.original
+                                + " -> " + config.fontScale);
+            }
             return;
         }
         logIfChanged(packageName + ":" + sourceTag,

--- a/app/src/main/java/com/dpis/module/ResourcesReadHookInstaller.java
+++ b/app/src/main/java/com/dpis/module/ResourcesReadHookInstaller.java
@@ -150,7 +150,7 @@ final class ResourcesReadHookInstaller {
                     && config.densityDpi != stableResult.densityDpi) {
                 config.densityDpi = stableResult.densityDpi;
                 logIfChanged(packageName + ":" + sourceTag + ":stable-target",
-                        "DPIS_FONT " + sourceTag + " stable target: widthDp="
+                        "DPIS_VIEWPORT " + sourceTag + " stable target: widthDp="
                                 + config.screenWidthDp
                                 + ", heightDp=" + config.screenHeightDp
                                 + ", smallestWidthDp=" + config.smallestScreenWidthDp
@@ -162,7 +162,7 @@ final class ResourcesReadHookInstaller {
             return;
         }
         logIfChanged(packageName + ":" + sourceTag,
-                "DPIS_FONT " + sourceTag + " override: widthDp " + originalWidthDp
+                "DPIS_VIEWPORT " + sourceTag + " override: widthDp " + originalWidthDp
                         + " -> " + config.screenWidthDp
                         + ", heightDp " + originalHeightDp + " -> " + config.screenHeightDp
                         + ", smallestWidthDp " + originalSmallestWidthDp + " -> "
@@ -195,7 +195,7 @@ final class ResourcesReadHookInstaller {
         }
 
         logIfChanged(packageName + ":ResourcesRead(getDisplayMetrics)",
-                "DPIS_FONT ResourcesRead(getDisplayMetrics) override: densityDpi="
+                "DPIS_VIEWPORT ResourcesRead(getDisplayMetrics) override: densityDpi="
                         + targetDensityDpi
                         + ", density=" + metrics.density
                         + ", scaledDensity=" + metrics.scaledDensity

--- a/app/src/main/java/com/dpis/module/SystemServerDisplayEnvironmentInstaller.java
+++ b/app/src/main/java/com/dpis/module/SystemServerDisplayEnvironmentInstaller.java
@@ -258,6 +258,7 @@ final class SystemServerDisplayEnvironmentInstaller {
                             .setExceptionMode(XposedInterface.ExceptionMode.PROTECTIVE)
                             .intercept(chain -> {
                                 Object result = null;
+                                boolean proceedAttempted = false;
                                 boolean proceeded = false;
                                 try {
                                     Object thisObject = chain.getThisObject();
@@ -315,6 +316,7 @@ final class SystemServerDisplayEnvironmentInstaller {
                                     if (shouldApplyPreProceedMutations(target.entryName)) {
                                         applyEnvironment(target.entryName, before, preEnvironment, config);
                                     }
+                                    proceedAttempted = true;
                                     result = chain.proceed();
                                     proceeded = true;
                                     Snapshot after = captureSnapshot(thisObject, args);
@@ -383,6 +385,9 @@ final class SystemServerDisplayEnvironmentInstaller {
                                             target.entryName, throwable), throwable);
                                     if (proceeded) {
                                         return result;
+                                    }
+                                    if (proceedAttempted) {
+                                        throw throwable;
                                     }
                                     return chain.proceed();
                                 }

--- a/app/src/main/java/com/dpis/module/ViewportModePolicy.java
+++ b/app/src/main/java/com/dpis/module/ViewportModePolicy.java
@@ -12,7 +12,7 @@ final class ViewportModePolicy {
     }
 
     static boolean shouldApplyConfigurationOverride(DpiConfigStore store, String packageName) {
-        return !ViewportApplyMode.FIELD_REWRITE.equals(resolve(store, packageName));
+        return ViewportApplyMode.isEnabled(resolve(store, packageName));
     }
 }
 

--- a/app/src/main/java/com/dpis/module/VirtualDisplayState.java
+++ b/app/src/main/java/com/dpis/module/VirtualDisplayState.java
@@ -10,6 +10,36 @@ final class VirtualDisplayState {
         current = result;
     }
 
+    static boolean setUnlessDerivedFromTargetConfig(VirtualDisplayOverride.Result result,
+                                                    int sourceSmallestWidthDp,
+                                                    Integer targetWidthDp) {
+        if (result == null) {
+            return false;
+        }
+        if (current != null
+                && targetWidthDp != null
+                && targetWidthDp > 0
+                && sourceSmallestWidthDp == targetWidthDp
+                && current.smallestWidthDp == targetWidthDp
+                && result.densityDpi != current.densityDpi) {
+            return false;
+        }
+        current = result;
+        return true;
+    }
+
+    static VirtualDisplayOverride.Result getStableTargetResult(int sourceSmallestWidthDp,
+                                                               Integer targetWidthDp) {
+        if (current == null
+                || targetWidthDp == null
+                || targetWidthDp <= 0
+                || sourceSmallestWidthDp != targetWidthDp
+                || current.smallestWidthDp != targetWidthDp) {
+            return null;
+        }
+        return current;
+    }
+
     static VirtualDisplayOverride.Result get() {
         return current;
     }

--- a/app/src/test/java/com/dpis/module/Compat100LegacyModuleHookSourceTest.java
+++ b/app/src/test/java/com/dpis/module/Compat100LegacyModuleHookSourceTest.java
@@ -22,6 +22,10 @@ public class Compat100LegacyModuleHookSourceTest {
         assertTrue(source.contains("DisplayHookInstaller.setTargetPackageNameForCompat100(packageName)"));
         assertTrue(source.contains("FONT_TEXTVIEW_UPDATE"));
         assertTrue(source.contains("installResourcesReadHooks(packageName, store)"));
+        assertTrue(source.contains("installResourcesKeyHooks("));
+        assertTrue(source.contains("ResourcesManagerHookInstaller.maybeApplyKeyOverride"));
+        assertTrue(source.contains("\"createResourcesImpl\".equals(methodName)"));
+        assertTrue(source.contains("\"android.content.res.ResourcesKey\".equals"));
         assertTrue(source.contains("ResourcesReadHookInstaller.applyConfigurationOverride"));
         assertTrue(source.contains("ResourcesReadHookInstaller.applyMetricsOverride"));
         assertTrue(source.contains("resolveActivePackageName(packageName)"));

--- a/app/src/test/java/com/dpis/module/DebugConfigBroadcastReceiverSourceTest.java
+++ b/app/src/test/java/com/dpis/module/DebugConfigBroadcastReceiverSourceTest.java
@@ -39,6 +39,7 @@ public class DebugConfigBroadcastReceiverSourceTest {
         assertTrue(source.contains("FontRuntimePropertySyncer.publishTargetAsync(packageName, fontScalePercent"));
         assertTrue(source.contains("store.setSystemServerSafeModeEnabled("));
         assertTrue(source.contains("store.setGlobalLogEnabled(loggingEnabled)"));
+        assertTrue(source.contains("store.setFontDebugOverlayEnabled("));
         assertTrue(source.contains("restartTargetAsync(packageName)"));
         assertTrue(source.contains("DPIS_DEBUG_CONFIG"));
     }

--- a/app/src/test/java/com/dpis/module/DebugConfigBroadcastReceiverSourceTest.java
+++ b/app/src/test/java/com/dpis/module/DebugConfigBroadcastReceiverSourceTest.java
@@ -1,0 +1,68 @@
+package com.dpis.module;
+
+import static org.junit.Assert.assertFalse;
+import static org.junit.Assert.assertTrue;
+
+import java.io.IOException;
+import java.nio.charset.StandardCharsets;
+import java.nio.file.Files;
+import java.nio.file.Path;
+
+import org.junit.Test;
+
+public class DebugConfigBroadcastReceiverSourceTest {
+    @Test
+    public void debugManifestExposesDebugConfigReceiverOnlyForDebugBuilds() throws IOException {
+        String debugManifest = read("src/debug/AndroidManifest.xml");
+        String mainManifest = read("src/main/AndroidManifest.xml");
+
+        assertTrue(debugManifest.contains(".DebugConfigActivity"));
+        assertTrue(debugManifest.contains(".DebugConfigBroadcastReceiver"));
+        assertTrue(debugManifest.contains("android:exported=\"true\""));
+        assertTrue(debugManifest.contains("io.github.kwensiu.dpis.DEBUG_SET_PACKAGE_CONFIG"));
+        assertFalse(mainManifest.contains("DebugConfigActivity"));
+        assertFalse(mainManifest.contains("DebugConfigBroadcastReceiver"));
+        assertFalse(mainManifest.contains("DEBUG_SET_PACKAGE_CONFIG"));
+    }
+
+    @Test
+    public void debugConfigApplierWritesConfigAndPublishesRuntimeProperties() throws IOException {
+        String source = read("src/debug/java/com/dpis/module/DebugConfigApplier.java");
+
+        assertTrue(source.contains("if (!BuildConfig.DEBUG)"));
+        assertTrue(source.contains("DpisApplication.getConfigStore()"));
+        assertTrue(source.contains("store.setTargetViewportWidthDp(packageName, widthDp)"));
+        assertTrue(source.contains("store.setTargetViewportApplyMode(packageName, normalizedMode)"));
+        assertTrue(source.contains("ViewportPropertySyncer.publishTargetAsync(packageName, widthDp, normalizedMode)"));
+        assertTrue(source.contains("store.setTargetFontScalePercent(packageName, fontScalePercent)"));
+        assertTrue(source.contains("store.setTargetFontApplyMode(packageName, normalizedMode)"));
+        assertTrue(source.contains("FontRuntimePropertySyncer.publishTargetAsync(packageName, fontScalePercent"));
+        assertTrue(source.contains("store.setSystemServerSafeModeEnabled("));
+        assertTrue(source.contains("store.setGlobalLogEnabled(loggingEnabled)"));
+        assertTrue(source.contains("restartTargetAsync(packageName)"));
+        assertTrue(source.contains("DPIS_DEBUG_CONFIG"));
+    }
+
+    @Test
+    public void debugConfigActivityAndReceiverUseSharedApplier() throws IOException {
+        String activity = read("src/debug/java/com/dpis/module/DebugConfigActivity.java");
+        String receiver = read("src/debug/java/com/dpis/module/DebugConfigBroadcastReceiver.java");
+
+        assertTrue(activity.contains("DebugConfigApplier.apply(this, getIntent(), false)"));
+        assertTrue(receiver.contains("DebugConfigApplier.apply(context, intent, true)"));
+    }
+
+    @Test
+    public void debugConfigClassesStayOutOfMainSourceSet() {
+        assertFalse(Files.exists(Path.of(
+                "src", "main", "java", "com", "dpis", "module", "DebugConfigActivity.java")));
+        assertFalse(Files.exists(Path.of(
+                "src", "main", "java", "com", "dpis", "module", "DebugConfigApplier.java")));
+        assertFalse(Files.exists(Path.of(
+                "src", "main", "java", "com", "dpis", "module", "DebugConfigBroadcastReceiver.java")));
+    }
+
+    private static String read(String relativePath) throws IOException {
+        return new String(Files.readAllBytes(Path.of(relativePath)), StandardCharsets.UTF_8);
+    }
+}

--- a/app/src/test/java/com/dpis/module/FontDebugStatsTransportSourceTest.java
+++ b/app/src/test/java/com/dpis/module/FontDebugStatsTransportSourceTest.java
@@ -1,0 +1,26 @@
+package com.dpis.module;
+
+import static org.junit.Assert.assertTrue;
+
+import java.io.IOException;
+import java.nio.charset.StandardCharsets;
+import java.nio.file.Files;
+import java.nio.file.Path;
+
+import org.junit.Test;
+
+public class FontDebugStatsTransportSourceTest {
+    @Test
+    public void targetProcessTransportDoesNotStartNonExportedModuleComponents() throws IOException {
+        String source = read("src/main/java/com/dpis/module/FontDebugStatsTransport.java");
+
+        assertTrue(source.contains("if (!isModuleContext(context))"));
+        assertTrue(source.contains("FontDebugStatsFileBridge.write(context, extras);"));
+        assertTrue(source.contains("return;"));
+        assertTrue(source.contains("BuildConfig.APPLICATION_ID.equals(context.getPackageName())"));
+    }
+
+    private static String read(String relativePath) throws IOException {
+        return new String(Files.readAllBytes(Path.of(relativePath)), StandardCharsets.UTF_8);
+    }
+}

--- a/app/src/test/java/com/dpis/module/ModuleMainHookInstallerTest.java
+++ b/app/src/test/java/com/dpis/module/ModuleMainHookInstallerTest.java
@@ -35,6 +35,27 @@ public class ModuleMainHookInstallerTest {
     }
 
     @Test
+    public void systemServerHookDoesNotRetryOriginalAfterProceedThrows() throws IOException {
+        String installer = read("src/main/java/com/dpis/module/SystemServerDisplayEnvironmentInstaller.java");
+
+        assertTrue(installer.contains("boolean proceedAttempted = false;"));
+        assertTrue(installer.contains("proceedAttempted = true;"));
+        assertTrue(installer.contains("if (proceedAttempted)"));
+        assertTrue(installer.contains("throw throwable;"));
+        assertTrue(installer.contains("return chain.proceed();"));
+    }
+
+    @Test
+    public void issueSpecificDiagnosticsDoNotRemainInRuntimeSources() throws IOException {
+        assertFalse(read("src/modern101/java/com/dpis/module/ModuleMain.java")
+                .contains("DPIS_DIAG"));
+        assertFalse(read("src/main/java/com/dpis/module/ConfigStoreFactory.java")
+                .contains("DPIS_DIAG"));
+        assertFalse(read("src/main/java/com/dpis/module/SystemServerDisplayEnvironmentInstaller.java")
+                .contains("DPIS_DIAG"));
+    }
+
+    @Test
     public void nativeFontHookUsesRustEnvironmentAsRuntimeFontSource() throws IOException {
         String nativeSource = read("src/main/cpp/dpis_native.cpp");
 

--- a/app/src/test/java/com/dpis/module/ResourcesImplHookInstallerTest.java
+++ b/app/src/test/java/com/dpis/module/ResourcesImplHookInstallerTest.java
@@ -158,6 +158,35 @@ public class ResourcesImplHookInstallerTest {
     }
 
     @Test
+    public void restoresStableDensityWhenTargetConfigWasReDerivedFromStaleMetrics() {
+        VirtualDisplayState.set(new VirtualDisplayOverride.Result(800, 1636, 800,
+                216, 1080, 2209));
+        Configuration config = new Configuration();
+        config.densityDpi = 456;
+        config.screenWidthDp = 800;
+        config.screenHeightDp = 1636;
+        config.smallestScreenWidthDp = 800;
+        config.fontScale = 1.0f;
+        DisplayMetrics metrics = new DisplayMetrics();
+        metrics.widthPixels = 1080;
+        metrics.heightPixels = 2208;
+        metrics.densityDpi = 456;
+        metrics.density = 2.85f;
+        metrics.scaledDensity = 2.85f;
+        FakePrefs prefs = new FakePrefs();
+        prefs.edit().putInt("viewport.bin.mt.plus.canary.width_dp", 800).commit();
+        DpiConfigStore store = new DpiConfigStore(prefs);
+
+        ResourcesImplHookInstaller.applyDensityOverride("bin.mt.plus.canary", config, metrics, store);
+
+        assertEquals(216, config.densityDpi);
+        assertEquals(216, metrics.densityDpi);
+        assertEquals(DensityOverride.densityFromDpi(216), metrics.density, 0.0001f);
+        assertEquals(1080, metrics.widthPixels);
+        assertEquals(2209, metrics.heightPixels);
+    }
+
+    @Test
     public void keepsSharedDensityStableWhenLandscapeConfigAlreadyMatchesTargetShortSide() {
         Configuration config = new Configuration();
         config.densityDpi = 480;

--- a/app/src/test/java/com/dpis/module/ResourcesManagerHookInstallerTest.java
+++ b/app/src/test/java/com/dpis/module/ResourcesManagerHookInstallerTest.java
@@ -1,0 +1,36 @@
+package com.dpis.module;
+
+import android.content.res.Configuration;
+
+import org.junit.After;
+import org.junit.Test;
+
+import static org.junit.Assert.assertEquals;
+
+public class ResourcesManagerHookInstallerTest {
+    @After
+    public void tearDown() {
+        VirtualDisplayState.set(null);
+    }
+
+    @Test
+    public void restoresStableDensityWhenTargetConfigWasReDerivedFromStaleDensity() {
+        VirtualDisplayState.set(new VirtualDisplayOverride.Result(800, 1636, 800,
+                216, 1080, 2209));
+        Configuration config = new Configuration();
+        config.densityDpi = 456;
+        config.screenWidthDp = 800;
+        config.screenHeightDp = 1636;
+        config.smallestScreenWidthDp = 800;
+        config.fontScale = 1.0f;
+        FakePrefs prefs = new FakePrefs();
+        prefs.edit().putInt("viewport.com.example.target.width_dp", 800).commit();
+        DpiConfigStore store = new DpiConfigStore(prefs);
+
+        ResourcesManagerHookInstaller.applyResourceOverrides(config, store, "com.example.target",
+                "ResourcesManager");
+
+        assertEquals(216, config.densityDpi);
+        assertEquals(216, VirtualDisplayState.get().densityDpi);
+    }
+}

--- a/app/src/test/java/com/dpis/module/ResourcesManagerHookInstallerTest.java
+++ b/app/src/test/java/com/dpis/module/ResourcesManagerHookInstallerTest.java
@@ -91,6 +91,36 @@ public class ResourcesManagerHookInstallerTest {
     }
 
     @Test
+    public void replacesResourcesKeyOverrideThatMatchesBaseActivityConfiguration() {
+        FakePrefs prefs = new FakePrefs();
+        prefs.edit()
+                .putInt("viewport.com.example.target.width_dp", 800)
+                .putString("viewport.com.example.target.mode", ViewportApplyMode.SYSTEM_EMULATION)
+                .commit();
+        DpiConfigStore store = new DpiConfigStore(prefs);
+        Configuration globalConfig = new Configuration();
+        globalConfig.screenWidthDp = 360;
+        globalConfig.screenHeightDp = 736;
+        globalConfig.smallestScreenWidthDp = 360;
+        globalConfig.densityDpi = 480;
+        globalConfig.fontScale = 1.0f;
+        FakeResourcesKey key = new FakeResourcesKey();
+        key.mOverrideConfiguration.screenWidthDp = 360;
+        key.mOverrideConfiguration.screenHeightDp = 736;
+        key.mOverrideConfiguration.smallestScreenWidthDp = 360;
+        key.mOverrideConfiguration.densityDpi = 480;
+
+        ResourcesManagerHookInstaller.maybeApplyKeyOverride(
+                new FakeResourcesManager(globalConfig), key, store,
+                "com.example.target", "createResourcesImpl");
+
+        assertEquals(800, key.mOverrideConfiguration.screenWidthDp);
+        assertEquals(1636, key.mOverrideConfiguration.screenHeightDp);
+        assertEquals(800, key.mOverrideConfiguration.smallestScreenWidthDp);
+        assertEquals(216, key.mOverrideConfiguration.densityDpi);
+    }
+
+    @Test
     public void preservesExistingResourcesKeyFontOnlyOverride() {
         FakePrefs prefs = new FakePrefs();
         prefs.edit()

--- a/app/src/test/java/com/dpis/module/ResourcesManagerHookInstallerTest.java
+++ b/app/src/test/java/com/dpis/module/ResourcesManagerHookInstallerTest.java
@@ -33,4 +33,106 @@ public class ResourcesManagerHookInstallerTest {
         assertEquals(216, config.densityDpi);
         assertEquals(216, VirtualDisplayState.get().densityDpi);
     }
+
+    @Test
+    public void fillsEmptyResourcesKeyOverrideFromGlobalConfiguration() {
+        FakePrefs prefs = new FakePrefs();
+        prefs.edit()
+                .putInt("viewport.com.example.target.width_dp", 800)
+                .putString("viewport.com.example.target.mode", ViewportApplyMode.FIELD_REWRITE)
+                .commit();
+        DpiConfigStore store = new DpiConfigStore(prefs);
+        Configuration globalConfig = new Configuration();
+        globalConfig.screenWidthDp = 360;
+        globalConfig.screenHeightDp = 736;
+        globalConfig.smallestScreenWidthDp = 360;
+        globalConfig.densityDpi = 480;
+        globalConfig.fontScale = 1.0f;
+        FakeResourcesManager resourcesManager = new FakeResourcesManager(globalConfig);
+        FakeResourcesKey key = new FakeResourcesKey();
+
+        ResourcesManagerHookInstaller.maybeApplyKeyOverride(
+                resourcesManager, key, store, "com.example.target", "createResourcesImpl");
+
+        assertEquals(800, key.mOverrideConfiguration.screenWidthDp);
+        assertEquals(1636, key.mOverrideConfiguration.screenHeightDp);
+        assertEquals(800, key.mOverrideConfiguration.smallestScreenWidthDp);
+        assertEquals(216, key.mOverrideConfiguration.densityDpi);
+        assertEquals(0.0f, key.mOverrideConfiguration.fontScale, 0.0001f);
+    }
+
+    @Test
+    public void keepsExistingResourcesKeyOverride() {
+        FakePrefs prefs = new FakePrefs();
+        prefs.edit()
+                .putInt("viewport.com.example.target.width_dp", 800)
+                .putString("viewport.com.example.target.mode", ViewportApplyMode.FIELD_REWRITE)
+                .commit();
+        DpiConfigStore store = new DpiConfigStore(prefs);
+        Configuration globalConfig = new Configuration();
+        globalConfig.screenWidthDp = 360;
+        globalConfig.screenHeightDp = 736;
+        globalConfig.smallestScreenWidthDp = 360;
+        globalConfig.densityDpi = 480;
+        FakeResourcesKey key = new FakeResourcesKey();
+        key.mOverrideConfiguration.screenWidthDp = 500;
+        key.mOverrideConfiguration.screenHeightDp = 1000;
+        key.mOverrideConfiguration.smallestScreenWidthDp = 500;
+        key.mOverrideConfiguration.densityDpi = 320;
+
+        ResourcesManagerHookInstaller.maybeApplyKeyOverride(
+                new FakeResourcesManager(globalConfig), key, store,
+                "com.example.target", "createResourcesImpl");
+
+        assertEquals(500, key.mOverrideConfiguration.screenWidthDp);
+        assertEquals(1000, key.mOverrideConfiguration.screenHeightDp);
+        assertEquals(500, key.mOverrideConfiguration.smallestScreenWidthDp);
+        assertEquals(320, key.mOverrideConfiguration.densityDpi);
+    }
+
+    @Test
+    public void preservesExistingResourcesKeyFontOnlyOverride() {
+        FakePrefs prefs = new FakePrefs();
+        prefs.edit()
+                .putInt("viewport.com.example.target.width_dp", 800)
+                .putString("viewport.com.example.target.mode", ViewportApplyMode.FIELD_REWRITE)
+                .commit();
+        DpiConfigStore store = new DpiConfigStore(prefs);
+        Configuration globalConfig = new Configuration();
+        globalConfig.screenWidthDp = 360;
+        globalConfig.screenHeightDp = 736;
+        globalConfig.smallestScreenWidthDp = 360;
+        globalConfig.densityDpi = 480;
+        globalConfig.fontScale = 1.0f;
+        FakeResourcesKey key = new FakeResourcesKey();
+        key.mOverrideConfiguration.fontScale = 0.5f;
+
+        ResourcesManagerHookInstaller.maybeApplyKeyOverride(
+                new FakeResourcesManager(globalConfig), key, store,
+                "com.example.target", "createResourcesImpl");
+
+        assertEquals(800, key.mOverrideConfiguration.screenWidthDp);
+        assertEquals(1636, key.mOverrideConfiguration.screenHeightDp);
+        assertEquals(800, key.mOverrideConfiguration.smallestScreenWidthDp);
+        assertEquals(216, key.mOverrideConfiguration.densityDpi);
+        assertEquals(0.5f, key.mOverrideConfiguration.fontScale, 0.0001f);
+    }
+
+    private static final class FakeResourcesManager {
+        private final Configuration configuration;
+
+        private FakeResourcesManager(Configuration configuration) {
+            this.configuration = configuration;
+        }
+
+        @SuppressWarnings("unused")
+        private Configuration getConfiguration() {
+            return configuration;
+        }
+    }
+
+    private static final class FakeResourcesKey {
+        @SuppressWarnings("unused")
+        private final Configuration mOverrideConfiguration = new Configuration();
+    }
 }

--- a/app/src/test/java/com/dpis/module/ResourcesReadHookInstallerTest.java
+++ b/app/src/test/java/com/dpis/module/ResourcesReadHookInstallerTest.java
@@ -1,0 +1,64 @@
+package com.dpis.module;
+
+import android.content.res.Configuration;
+import android.util.DisplayMetrics;
+
+import org.junit.After;
+import org.junit.Test;
+
+import static org.junit.Assert.assertEquals;
+
+public class ResourcesReadHookInstallerTest {
+    @After
+    public void tearDown() {
+        VirtualDisplayState.set(null);
+    }
+
+    @Test
+    public void restoresStableDensityWhenTargetConfigWasReDerivedFromStaleDensity() {
+        VirtualDisplayState.set(new VirtualDisplayOverride.Result(800, 1636, 800,
+                216, 1080, 2209));
+        Configuration config = new Configuration();
+        config.densityDpi = 456;
+        config.screenWidthDp = 800;
+        config.screenHeightDp = 1636;
+        config.smallestScreenWidthDp = 800;
+        config.fontScale = 1.0f;
+        FakePrefs prefs = new FakePrefs();
+        prefs.edit().putInt("viewport.com.example.target.width_dp", 800).commit();
+        DpiConfigStore store = new DpiConfigStore(prefs);
+
+        ResourcesReadHookInstaller.applyConfigurationOverride(config, "com.example.target", store,
+                "ResourcesRead(getConfiguration)");
+
+        assertEquals(216, config.densityDpi);
+        assertEquals(216, VirtualDisplayState.get().densityDpi);
+    }
+
+    @Test
+    public void metricsUseStableDensityAfterConfigurationRestoration() {
+        VirtualDisplayState.set(new VirtualDisplayOverride.Result(800, 1636, 800,
+                216, 1080, 2209));
+        Configuration config = new Configuration();
+        config.densityDpi = 216;
+        config.screenWidthDp = 800;
+        config.screenHeightDp = 1636;
+        config.smallestScreenWidthDp = 800;
+        config.fontScale = 0.5f;
+        DisplayMetrics metrics = new DisplayMetrics();
+        metrics.densityDpi = 456;
+        metrics.density = 2.85f;
+        metrics.scaledDensity = 2.85f;
+        metrics.widthPixels = 1080;
+        metrics.heightPixels = 2208;
+
+        ResourcesReadHookInstaller.applyMetricsOverride(metrics, config, "com.example.target");
+
+        assertEquals(216, metrics.densityDpi);
+        assertEquals(DensityOverride.densityFromDpi(216), metrics.density, 0.0001f);
+        assertEquals(DensityOverride.scaledDensityFrom(216, 0.5f),
+                metrics.scaledDensity, 0.0001f);
+        assertEquals(1080, metrics.widthPixels);
+        assertEquals(2209, metrics.heightPixels);
+    }
+}

--- a/app/src/test/java/com/dpis/module/ViewportModePolicyTest.java
+++ b/app/src/test/java/com/dpis/module/ViewportModePolicyTest.java
@@ -32,4 +32,18 @@ public class ViewportModePolicyTest {
         assertEquals(ViewportApplyMode.SYSTEM_EMULATION, mode);
         assertTrue(ViewportModePolicy.shouldApplyConfigurationOverride(store, "com.example.target"));
     }
+
+    @Test
+    public void fieldRewriteAppliesConfigurationOverrideInAppProcess() {
+        FakePrefs prefs = new FakePrefs();
+        DpiConfigStore store = new DpiConfigStore(prefs);
+        store.setSystemServerHooksEnabled(false);
+        store.setTargetViewportWidthDp("com.example.target", 360);
+        store.setTargetViewportApplyMode("com.example.target", ViewportApplyMode.FIELD_REWRITE);
+
+        String mode = ViewportModePolicy.resolve(store, "com.example.target");
+
+        assertEquals(ViewportApplyMode.FIELD_REWRITE, mode);
+        assertTrue(ViewportModePolicy.shouldApplyConfigurationOverride(store, "com.example.target"));
+    }
 }

--- a/app/src/test/java/com/dpis/module/VirtualDisplayStateTest.java
+++ b/app/src/test/java/com/dpis/module/VirtualDisplayStateTest.java
@@ -1,0 +1,77 @@
+package com.dpis.module;
+
+import org.junit.After;
+import org.junit.Test;
+
+import static org.junit.Assert.assertEquals;
+import static org.junit.Assert.assertFalse;
+import static org.junit.Assert.assertTrue;
+
+public class VirtualDisplayStateTest {
+    @After
+    public void tearDown() {
+        VirtualDisplayState.set(null);
+    }
+
+    @Test
+    public void doesNotReplaceExistingStateWhenSourceConfigAlreadyMatchesTarget() {
+        VirtualDisplayState.set(new VirtualDisplayOverride.Result(800, 1636, 800,
+                216, 1080, 2209));
+        VirtualDisplayOverride.Result inflated = new VirtualDisplayOverride.Result(800, 1636,
+                800, 456, 2280, 4663);
+
+        boolean changed = VirtualDisplayState.setUnlessDerivedFromTargetConfig(
+                inflated, 800, 800);
+
+        assertFalse(changed);
+        assertEquals(1080, VirtualDisplayState.get().widthPx);
+        assertEquals(216, VirtualDisplayState.get().densityDpi);
+    }
+
+    @Test
+    public void doesNotReplaceExistingStateWithLowerDensityDerivedFromTargetConfig() {
+        VirtualDisplayState.set(new VirtualDisplayOverride.Result(800, 1636, 800,
+                216, 1080, 2209));
+        VirtualDisplayOverride.Result appBrand = new VirtualDisplayOverride.Result(800, 1636,
+                800, 160, 800, 1636);
+
+        boolean changed = VirtualDisplayState.setUnlessDerivedFromTargetConfig(
+                appBrand, 800, 800);
+
+        assertFalse(changed);
+        assertEquals(1080, VirtualDisplayState.get().widthPx);
+        assertEquals(216, VirtualDisplayState.get().densityDpi);
+    }
+
+    @Test
+    public void initializesStateWhenNoExistingStateIsAvailable() {
+        VirtualDisplayOverride.Result result = new VirtualDisplayOverride.Result(800, 1636,
+                800, 216, 1080, 2209);
+
+        boolean changed = VirtualDisplayState.setUnlessDerivedFromTargetConfig(
+                result, 360, 800);
+
+        assertTrue(changed);
+        assertEquals(1080, VirtualDisplayState.get().widthPx);
+    }
+
+    @Test
+    public void exposesStableResultForAlreadyTargetConfig() {
+        VirtualDisplayState.set(new VirtualDisplayOverride.Result(800, 1636, 800,
+                216, 1080, 2209));
+
+        VirtualDisplayOverride.Result result =
+                VirtualDisplayState.getStableTargetResult(800, 800);
+
+        assertEquals(216, result.densityDpi);
+        assertEquals(1080, result.widthPx);
+    }
+
+    @Test
+    public void doesNotExposeStableResultForNonTargetConfig() {
+        VirtualDisplayState.set(new VirtualDisplayOverride.Result(800, 1636, 800,
+                216, 1080, 2209));
+
+        assertEquals(null, VirtualDisplayState.getStableTargetResult(360, 800));
+    }
+}


### PR DESCRIPTION
修复 issue #46 中 API101/API100 下部分应用资源视口覆盖不完整的问题。

- 为 compat100 补上 `ResourcesManager.createResourcesImpl(ResourcesKey...)` 链路
- 修复非空 `ResourcesKey` override config 未被替换的问题
- 添加新 debug-only 配置接口
