### PR TITLE
refactor: package config aggregation

### DIFF
--- a/app/build.gradle.kts
+++ b/app/build.gradle.kts
@@ -14,7 +14,7 @@ plugins {
     alias(libs.plugins.aboutlibraries)
 }
 
-private val appVersionName = "1.13.1" // x-release-please-version
+private val appVersionName = "1.13.0" // x-release-please-version
 private val defaultNdkVersion = "28.2.13676358"
 private val defaultCmakeVersion = "3.22.1"
 

--- a/app/src/main/java/com/dpis/module/AppConfigPrefillPreview.java
+++ b/app/src/main/java/com/dpis/module/AppConfigPrefillPreview.java
@@ -7,10 +7,22 @@ final class AppConfigPrefillPreview {
     static AppListItem applyIfEligible(AppListItem item,
             DpiConfigStore store,
             TemplateConfigValue globalPrefill) {
-        if (item == null || store == null || globalPrefill == null || !globalPrefill.hasAnyValue()) {
+        if (store == null) {
             return item;
         }
-        if (store.hasRealPackageConfig(item.packageName)) {
+        return applyIfEligible(item, new PackageConfigRepository(store), globalPrefill);
+    }
+
+    private static AppListItem applyIfEligible(AppListItem item,
+            PackageConfigRepository packageConfigRepository,
+            TemplateConfigValue globalPrefill) {
+        if (item == null
+                || packageConfigRepository == null
+                || globalPrefill == null
+                || !globalPrefill.hasAnyValue()) {
+            return item;
+        }
+        if (packageConfigRepository.hasRealPackageConfig(item.packageName)) {
             return item;
         }
         return item.withGlobalPrefillPreview(globalPrefill);

--- a/app/src/main/java/com/dpis/module/ConfigBackupCodec.java
+++ b/app/src/main/java/com/dpis/module/ConfigBackupCodec.java
@@ -14,7 +14,7 @@ import java.util.Map;
 import java.util.Set;
 
 final class ConfigBackupCodec {
-    private static final int SCHEMA_VERSION = 1;
+    private static final int SCHEMA_VERSION = 2;
 
     private static final String KEY_SCHEMA_VERSION = "schemaVersion";
     private static final String KEY_CREATED_AT_EPOCH_MS = "createdAtEpochMs";
@@ -22,6 +22,7 @@ final class ConfigBackupCodec {
     private static final String KEY_APP_VERSION_CODE = "appVersionCode";
     private static final String KEY_APP_VERSION_NAME = "appVersionName";
     private static final String KEY_ENTRIES = "entries";
+    private static final String KEY_PACKAGE_CONFIGS = "packageConfigs";
     private static final String KEY_TYPE = "type";
     private static final String KEY_VALUE = "value";
 
@@ -31,6 +32,18 @@ final class ConfigBackupCodec {
     private static final String TYPE_LONG = "long";
     private static final String TYPE_FLOAT = "float";
     private static final String TYPE_BOOLEAN = "boolean";
+    private static final String[] PACKAGE_CONFIG_FIELD_KEYS = {
+            "viewport.width_dp",
+            "viewport.target_type",
+            "viewport.scale_permille",
+            "viewport.mode",
+            "font.scale_percent",
+            "font.typeface_id",
+            "font.mode",
+            "font.hook_domains",
+            "target.dpis_enabled",
+            "app.wechat_dpi"
+    };
 
     private ConfigBackupCodec() {
     }
@@ -44,6 +57,7 @@ final class ConfigBackupCodec {
         root.put(KEY_APP_VERSION_NAME, BuildConfig.VERSION_NAME);
 
         JSONObject encodedEntries = new JSONObject();
+        JSONObject encodedPackageConfigs = new JSONObject();
         List<String> keys = new ArrayList<>(entries.keySet());
         Collections.sort(keys);
         for (String key : keys) {
@@ -52,24 +66,54 @@ final class ConfigBackupCodec {
             }
             JSONObject encoded = encodeValue(entries.get(key));
             if (encoded != null) {
-                encodedEntries.put(key, encoded);
+                if (!putEncodedPackageConfigEntry(encodedPackageConfigs, key, encoded)) {
+                    encodedEntries.put(key, encoded);
+                }
             }
         }
         root.put(KEY_ENTRIES, encodedEntries);
+        if (encodedPackageConfigs.length() > 0) {
+            root.put(KEY_PACKAGE_CONFIGS, encodedPackageConfigs);
+        }
         return root.toString(2);
     }
 
     static Map<String, Object> decode(String rawJson) throws JSONException {
         JSONObject root = new JSONObject(rawJson);
         int schemaVersion = root.optInt(KEY_SCHEMA_VERSION, -1);
+        if (schemaVersion == 1) {
+            return decodeSchemaV1(root);
+        }
         if (schemaVersion != SCHEMA_VERSION) {
             throw new IllegalArgumentException("Unsupported backup schema version: " + schemaVersion);
         }
+        LinkedHashMap<String, Object> entries = new LinkedHashMap<>();
+        JSONObject encodedEntries = root.optJSONObject(KEY_ENTRIES);
+        if (encodedEntries != null) {
+            decodeEntrySectionInto(entries, encodedEntries);
+        }
+        JSONObject encodedPackageConfigs = root.optJSONObject(KEY_PACKAGE_CONFIGS);
+        if (encodedPackageConfigs != null) {
+            decodePackageConfigsInto(entries, encodedPackageConfigs);
+        }
+        if (encodedEntries == null && encodedPackageConfigs == null) {
+            throw new IllegalArgumentException("Missing entries section");
+        }
+        return entries;
+    }
+
+    private static Map<String, Object> decodeSchemaV1(JSONObject root) throws JSONException {
         JSONObject encodedEntries = root.optJSONObject(KEY_ENTRIES);
         if (encodedEntries == null) {
             throw new IllegalArgumentException("Missing entries section");
         }
         LinkedHashMap<String, Object> entries = new LinkedHashMap<>();
+        decodeEntrySectionInto(entries, encodedEntries);
+        return entries;
+    }
+
+    private static void decodeEntrySectionInto(Map<String, Object> entries, JSONObject encodedEntries)
+            throws JSONException {
         Iterator<String> keys = encodedEntries.keys();
         while (keys.hasNext()) {
             String key = keys.next();
@@ -82,7 +126,75 @@ final class ConfigBackupCodec {
             }
             entries.put(key, decodeValue(encodedValue));
         }
-        return entries;
+    }
+
+    private static boolean putEncodedPackageConfigEntry(
+            JSONObject encodedPackageConfigs,
+            String key,
+            JSONObject encodedValue) throws JSONException {
+        String prefix = "package_config.";
+        if (!key.startsWith(prefix)) {
+            return false;
+        }
+        String remainder = key.substring(prefix.length());
+        String fieldKey = packageConfigFieldKeyFromRemainder(remainder);
+        if (fieldKey == null) {
+            return false;
+        }
+        String packageName = remainder.substring(0, remainder.length() - fieldKey.length() - 1);
+        if (packageName.isEmpty() || fieldKey.isEmpty()) {
+            return false;
+        }
+        JSONObject packageEntries = encodedPackageConfigs.optJSONObject(packageName);
+        if (packageEntries == null) {
+            packageEntries = new JSONObject();
+            encodedPackageConfigs.put(packageName, packageEntries);
+        }
+        packageEntries.put(fieldKey, encodedValue);
+        return true;
+    }
+
+    private static String packageConfigFieldKeyFromRemainder(String remainder) {
+        if (remainder == null || remainder.isEmpty()) {
+            return null;
+        }
+        for (String fieldKey : PACKAGE_CONFIG_FIELD_KEYS) {
+            if (remainder.endsWith("." + fieldKey)) {
+                return fieldKey;
+            }
+        }
+        return null;
+    }
+
+    private static void decodePackageConfigsInto(
+            Map<String, Object> entries,
+            JSONObject encodedPackageConfigs) throws JSONException {
+        Iterator<String> packageNames = encodedPackageConfigs.keys();
+        while (packageNames.hasNext()) {
+            String packageName = packageNames.next();
+            if (packageName == null || packageName.isEmpty()) {
+                continue;
+            }
+            JSONObject packageEntries = encodedPackageConfigs.optJSONObject(packageName);
+            if (packageEntries == null) {
+                throw new IllegalArgumentException(
+                        "Invalid package config payload for package: " + packageName);
+            }
+            Iterator<String> fieldKeys = packageEntries.keys();
+            while (fieldKeys.hasNext()) {
+                String fieldKey = fieldKeys.next();
+                if (fieldKey == null || fieldKey.isEmpty()) {
+                    continue;
+                }
+                JSONObject encodedValue = packageEntries.optJSONObject(fieldKey);
+                if (encodedValue == null) {
+                    throw new IllegalArgumentException(
+                            "Invalid package config entry for package: " + packageName
+                                    + ", key: " + fieldKey);
+                }
+                entries.put("package_config." + packageName + "." + fieldKey, decodeValue(encodedValue));
+            }
+        }
     }
 
     @SuppressWarnings("unchecked")

--- a/app/src/main/java/com/dpis/module/ConfigBackupCodec.java
+++ b/app/src/main/java/com/dpis/module/ConfigBackupCodec.java
@@ -1,6 +1,7 @@
 package com.dpis.module;
 
 import org.json.JSONException;
+import org.json.JSONArray;
 import org.json.JSONObject;
 
 import java.util.ArrayList;
@@ -13,7 +14,7 @@ import java.util.Map;
 import java.util.Set;
 
 final class ConfigBackupCodec {
-    private static final int SCHEMA_VERSION = 2;
+    private static final int SCHEMA_VERSION = 3;
 
     private static final String KEY_SCHEMA_VERSION = "schemaVersion";
     private static final String KEY_CREATED_AT_EPOCH_MS = "createdAtEpochMs";
@@ -22,6 +23,11 @@ final class ConfigBackupCodec {
     private static final String KEY_APP_VERSION_NAME = "appVersionName";
     private static final String KEY_ENTRIES = "entries";
     private static final String KEY_PACKAGE_CONFIGS = "packageConfigs";
+    private static final String KEY_RESOLUTION_CONFIGS = "resolutionConfigs";
+    private static final String KEY_GLOBAL = "global";
+    private static final String KEY_DEFAULT_PREFILL = "defaultPrefill";
+    private static final String KEY_TEMPLATES = "templates";
+    private static final String KEY_TEMPLATE_META = "_meta";
     private static final String KEY_TYPE = "type";
     private static final String KEY_VALUE = "value";
     private static final String[] PACKAGE_CONFIG_FIELD_KEYS = {
@@ -36,6 +42,11 @@ final class ConfigBackupCodec {
             "target.dpis_enabled",
             "app.wechat_dpi"
     };
+    private static final String[] RESOLUTION_CONFIG_FIELD_KEYS = {
+            "width_px",
+            "height_px",
+            "mode"
+    };
 
     private ConfigBackupCodec() {
     }
@@ -48,8 +59,11 @@ final class ConfigBackupCodec {
         root.put(KEY_APP_VERSION_CODE, BuildConfig.VERSION_CODE);
         root.put(KEY_APP_VERSION_NAME, BuildConfig.VERSION_NAME);
 
-        JSONObject encodedEntries = new JSONObject();
         JSONObject encodedPackageConfigs = new JSONObject();
+        JSONObject encodedResolutionConfigs = new JSONObject();
+        JSONObject encodedGlobal = new JSONObject();
+        JSONObject encodedDefaultPrefill = new JSONObject();
+        JSONObject encodedTemplates = new JSONObject();
         List<String> keys = new ArrayList<>(entries.keySet());
         Collections.sort(keys);
         for (String key : keys) {
@@ -60,14 +74,39 @@ final class ConfigBackupCodec {
             if (putPackageConfigEntry(encodedPackageConfigs, key, value)) {
                 continue;
             }
-            JSONObject encoded = encodeValue(value);
+            if (putPackageOwnedConfigEntry(
+                    encodedResolutionConfigs,
+                    "resolution.",
+                    RESOLUTION_CONFIG_FIELD_KEYS,
+                    key,
+                    value)) {
+                continue;
+            }
+            if (putDefaultPrefillEntry(encodedDefaultPrefill, key, value)) {
+                continue;
+            }
+            if (putTemplateEntry(encodedTemplates, key, value)) {
+                continue;
+            }
+            Object encoded = encodeDirectValue(value);
             if (encoded != null) {
-                encodedEntries.put(key, encoded);
+                putNestedValue(encodedGlobal, key, encoded);
             }
         }
-        root.put(KEY_ENTRIES, encodedEntries);
         if (encodedPackageConfigs.length() > 0) {
             root.put(KEY_PACKAGE_CONFIGS, encodedPackageConfigs);
+        }
+        if (encodedResolutionConfigs.length() > 0) {
+            root.put(KEY_RESOLUTION_CONFIGS, encodedResolutionConfigs);
+        }
+        if (encodedGlobal.length() > 0) {
+            root.put(KEY_GLOBAL, encodedGlobal);
+        }
+        if (encodedDefaultPrefill.length() > 0) {
+            root.put(KEY_DEFAULT_PREFILL, encodedDefaultPrefill);
+        }
+        if (encodedTemplates.length() > 0) {
+            root.put(KEY_TEMPLATES, encodedTemplates);
         }
         return root.toString(2);
     }
@@ -78,6 +117,9 @@ final class ConfigBackupCodec {
         if (schemaVersion == 1) {
             return decodeSchemaV1(root);
         }
+        if (schemaVersion == 2) {
+            return decodeSchemaV2(root);
+        }
         if (schemaVersion != SCHEMA_VERSION) {
             throw new IllegalArgumentException("Unsupported backup schema version: " + schemaVersion);
         }
@@ -86,11 +128,27 @@ final class ConfigBackupCodec {
         if (encodedPackageConfigs != null) {
             decodePackageConfigsInto(entries, encodedPackageConfigs);
         }
-        JSONObject encodedEntries = root.optJSONObject(KEY_ENTRIES);
-        if (encodedEntries != null) {
-            decodeEntrySectionInto(entries, encodedEntries);
+        JSONObject encodedResolutionConfigs = root.optJSONObject(KEY_RESOLUTION_CONFIGS);
+        if (encodedResolutionConfigs != null) {
+            decodePackageOwnedConfigsInto(entries, "resolution.", encodedResolutionConfigs);
         }
-        if (encodedEntries == null && encodedPackageConfigs == null) {
+        JSONObject encodedGlobal = root.optJSONObject(KEY_GLOBAL);
+        if (encodedGlobal != null) {
+            decodeDirectSectionInto(entries, "", encodedGlobal);
+        }
+        JSONObject encodedDefaultPrefill = root.optJSONObject(KEY_DEFAULT_PREFILL);
+        if (encodedDefaultPrefill != null) {
+            decodeDirectSectionInto(entries, "default_config.", encodedDefaultPrefill);
+        }
+        JSONObject encodedTemplates = root.optJSONObject(KEY_TEMPLATES);
+        if (encodedTemplates != null) {
+            decodeTemplatesInto(entries, encodedTemplates);
+        }
+        if (encodedPackageConfigs == null
+                && encodedResolutionConfigs == null
+                && encodedGlobal == null
+                && encodedDefaultPrefill == null
+                && encodedTemplates == null) {
             throw new IllegalArgumentException("Missing entries section");
         }
         return entries;
@@ -103,6 +161,22 @@ final class ConfigBackupCodec {
         }
         LinkedHashMap<String, Object> entries = new LinkedHashMap<>();
         decodeEntrySectionInto(entries, encodedEntries);
+        return entries;
+    }
+
+    private static Map<String, Object> decodeSchemaV2(JSONObject root) throws JSONException {
+        LinkedHashMap<String, Object> entries = new LinkedHashMap<>();
+        JSONObject encodedPackageConfigs = root.optJSONObject(KEY_PACKAGE_CONFIGS);
+        if (encodedPackageConfigs != null) {
+            decodePackageConfigsInto(entries, encodedPackageConfigs);
+        }
+        JSONObject encodedEntries = root.optJSONObject(KEY_ENTRIES);
+        if (encodedEntries != null) {
+            decodeEntrySectionInto(entries, encodedEntries);
+        }
+        if (encodedEntries == null && encodedPackageConfigs == null) {
+            throw new IllegalArgumentException("Missing entries section");
+        }
         return entries;
     }
 
@@ -144,7 +218,100 @@ final class ConfigBackupCodec {
             packageEntries = new JSONObject();
             encodedPackageConfigs.put(packageName, packageEntries);
         }
-        packageEntries.put(fieldKey, value);
+        String domain = fieldKey.substring(0, fieldKey.indexOf('.'));
+        String field = fieldKey.substring(domain.length() + 1);
+        JSONObject domainEntries = packageEntries.optJSONObject(domain);
+        if (domainEntries == null) {
+            domainEntries = new JSONObject();
+            packageEntries.put(domain, domainEntries);
+        }
+        Object encoded = encodeDirectValue(value);
+        if (encoded != null) {
+            putNestedValue(domainEntries, field, encoded);
+        }
+        return true;
+    }
+
+    private static boolean putPackageOwnedConfigEntry(
+            JSONObject encodedPackages,
+            String prefix,
+            String[] fieldKeys,
+            String key,
+            Object value) throws JSONException {
+        if (!key.startsWith(prefix)) {
+            return false;
+        }
+        String remainder = key.substring(prefix.length());
+        String fieldKey = fieldKeyFromRemainder(remainder, fieldKeys);
+        if (fieldKey == null) {
+            return false;
+        }
+        String packageName = remainder.substring(0, remainder.length() - fieldKey.length() - 1);
+        if (packageName.isEmpty()) {
+            return false;
+        }
+        Object encoded = encodeDirectValue(value);
+        if (encoded == null) {
+            return true;
+        }
+        JSONObject packageEntries = encodedPackages.optJSONObject(packageName);
+        if (packageEntries == null) {
+            packageEntries = new JSONObject();
+            encodedPackages.put(packageName, packageEntries);
+        }
+        putNestedValue(packageEntries, fieldKey, encoded);
+        return true;
+    }
+
+    private static boolean putDefaultPrefillEntry(
+            JSONObject encodedDefaultPrefill,
+            String key,
+            Object value) throws JSONException {
+        String prefix = "default_config.";
+        if (!key.startsWith(prefix)) {
+            return false;
+        }
+        Object encoded = encodeDirectValue(value);
+        if (encoded != null) {
+            putNestedValue(encodedDefaultPrefill, key.substring(prefix.length()), encoded);
+        }
+        return true;
+    }
+
+    private static boolean putTemplateEntry(
+            JSONObject encodedTemplates,
+            String key,
+            Object value) throws JSONException {
+        String prefix = "template.";
+        if (!key.startsWith(prefix)) {
+            return false;
+        }
+        Object encoded = encodeDirectValue(value);
+        if (encoded == null) {
+            return true;
+        }
+        String remainder = key.substring(prefix.length());
+        if ("ids".equals(remainder) || "order".equals(remainder)) {
+            JSONObject meta = encodedTemplates.optJSONObject(KEY_TEMPLATE_META);
+            if (meta == null) {
+                meta = new JSONObject();
+                encodedTemplates.put(KEY_TEMPLATE_META, meta);
+            }
+            meta.put(remainder, encoded);
+            return true;
+        }
+        int dot = remainder.indexOf('.');
+        if (dot <= 0 || dot == remainder.length() - 1) {
+            return true;
+        }
+        String templateId = remainder.substring(0, dot);
+        String templateKey = remainder.substring(dot + 1);
+        JSONObject template = encodedTemplates.optJSONObject(templateId);
+        if (template == null) {
+            template = new JSONObject();
+            encodedTemplates.put(templateId, template);
+        }
+        putNestedValue(template, templateKey, encoded);
         return true;
     }
 
@@ -153,6 +320,18 @@ final class ConfigBackupCodec {
             return null;
         }
         for (String fieldKey : PACKAGE_CONFIG_FIELD_KEYS) {
+            if (remainder.endsWith("." + fieldKey)) {
+                return fieldKey;
+            }
+        }
+        return null;
+    }
+
+    private static String fieldKeyFromRemainder(String remainder, String[] fieldKeys) {
+        if (remainder == null || remainder.isEmpty()) {
+            return null;
+        }
+        for (String fieldKey : fieldKeys) {
             if (remainder.endsWith("." + fieldKey)) {
                 return fieldKey;
             }
@@ -176,13 +355,135 @@ final class ConfigBackupCodec {
             }
             Iterator<String> fieldKeys = packageEntries.keys();
             while (fieldKeys.hasNext()) {
-                String fieldKey = fieldKeys.next();
-                if (fieldKey == null || fieldKey.isEmpty()) {
+                String domain = fieldKeys.next();
+                if (domain == null || domain.isEmpty()) {
                     continue;
                 }
-                entries.put("package_config." + packageName + "." + fieldKey, packageEntries.get(fieldKey));
+                Object domainValue = packageEntries.get(domain);
+                if (domainValue instanceof JSONObject domainEntries) {
+                    decodeDirectSectionInto(entries,
+                            "package_config." + packageName + "." + domain + ".",
+                            domainEntries);
+                } else {
+                    entries.put("package_config." + packageName + "." + domain,
+                            decodeDirectValue(domainValue));
+                }
             }
         }
+    }
+
+    private static void decodeTemplatesInto(
+            Map<String, Object> entries,
+            JSONObject encodedTemplates) throws JSONException {
+        Iterator<String> templateIds = encodedTemplates.keys();
+        while (templateIds.hasNext()) {
+            String templateId = templateIds.next();
+            if (templateId == null || templateId.isEmpty()) {
+                continue;
+            }
+            JSONObject template = encodedTemplates.optJSONObject(templateId);
+            if (template == null) {
+                throw new IllegalArgumentException(
+                        "Invalid template payload for template: " + templateId);
+            }
+            if (KEY_TEMPLATE_META.equals(templateId)) {
+                decodeDirectSectionInto(entries, "template.", template);
+            } else {
+                decodeDirectSectionInto(entries, "template." + templateId + ".", template);
+            }
+        }
+    }
+
+    private static void decodePackageOwnedConfigsInto(
+            Map<String, Object> entries,
+            String prefix,
+            JSONObject encodedPackages) throws JSONException {
+        Iterator<String> packageNames = encodedPackages.keys();
+        while (packageNames.hasNext()) {
+            String packageName = packageNames.next();
+            if (packageName == null || packageName.isEmpty()) {
+                continue;
+            }
+            JSONObject packageEntries = encodedPackages.optJSONObject(packageName);
+            if (packageEntries == null) {
+                throw new IllegalArgumentException(
+                        "Invalid package-owned config payload for package: " + packageName);
+            }
+            decodeDirectSectionInto(entries, prefix + packageName + ".", packageEntries);
+        }
+    }
+
+    private static void decodeDirectSectionInto(
+            Map<String, Object> entries,
+            String prefix,
+            JSONObject section) throws JSONException {
+        decodeDirectSectionInto(entries, prefix, "", section);
+    }
+
+    private static void decodeDirectSectionInto(
+            Map<String, Object> entries,
+            String prefix,
+            String path,
+            JSONObject section) throws JSONException {
+        Iterator<String> keys = section.keys();
+        while (keys.hasNext()) {
+            String key = keys.next();
+            if (key == null || key.isEmpty()) {
+                continue;
+            }
+            Object value = section.get(key);
+            String nextPath = path.isEmpty() ? key : path + "." + key;
+            if (value instanceof JSONObject nested) {
+                decodeDirectSectionInto(entries, prefix, nextPath, nested);
+            } else {
+                entries.put(prefix + nextPath, decodeDirectValue(value));
+            }
+        }
+    }
+
+    private static void putNestedValue(JSONObject section, String path, Object value)
+            throws JSONException {
+        int dot = path.indexOf('.');
+        if (dot < 0) {
+            section.put(path, value);
+            return;
+        }
+        String head = path.substring(0, dot);
+        String tail = path.substring(dot + 1);
+        JSONObject nested = section.optJSONObject(head);
+        if (nested == null) {
+            nested = new JSONObject();
+            section.put(head, nested);
+        }
+        putNestedValue(nested, tail, value);
+    }
+
+    private static Object encodeDirectValue(Object value) throws JSONException {
+        if (value instanceof Set<?> typed) {
+            List<String> values = new ArrayList<>();
+            for (Object item : typed) {
+                if (item instanceof String text) {
+                    values.add(text);
+                }
+            }
+            Collections.sort(values);
+            return new JSONArray(values);
+        }
+        if (value instanceof String
+                || value instanceof Integer
+                || value instanceof Long
+                || value instanceof Float
+                || value instanceof Boolean) {
+            return value;
+        }
+        return null;
+    }
+
+    private static Object decodeDirectValue(Object value) throws JSONException {
+        if (value instanceof JSONArray array) {
+            return decodeStringSet(array);
+        }
+        return value;
     }
 
     private static JSONObject encodeValue(Object value) throws JSONException {

--- a/app/src/main/java/com/dpis/module/ConfigBackupCodec.java
+++ b/app/src/main/java/com/dpis/module/ConfigBackupCodec.java
@@ -1,6 +1,5 @@
 package com.dpis.module;
 
-import org.json.JSONArray;
 import org.json.JSONException;
 import org.json.JSONObject;
 
@@ -25,13 +24,6 @@ final class ConfigBackupCodec {
     private static final String KEY_PACKAGE_CONFIGS = "packageConfigs";
     private static final String KEY_TYPE = "type";
     private static final String KEY_VALUE = "value";
-
-    private static final String TYPE_STRING = "string";
-    private static final String TYPE_STRING_SET = "string_set";
-    private static final String TYPE_INT = "int";
-    private static final String TYPE_LONG = "long";
-    private static final String TYPE_FLOAT = "float";
-    private static final String TYPE_BOOLEAN = "boolean";
     private static final String[] PACKAGE_CONFIG_FIELD_KEYS = {
             "viewport.width_dp",
             "viewport.target_type",
@@ -64,11 +56,13 @@ final class ConfigBackupCodec {
             if (key == null || key.isEmpty()) {
                 continue;
             }
-            JSONObject encoded = encodeValue(entries.get(key));
+            Object value = entries.get(key);
+            if (putPackageConfigEntry(encodedPackageConfigs, key, value)) {
+                continue;
+            }
+            JSONObject encoded = encodeValue(value);
             if (encoded != null) {
-                if (!putEncodedPackageConfigEntry(encodedPackageConfigs, key, encoded)) {
-                    encodedEntries.put(key, encoded);
-                }
+                encodedEntries.put(key, encoded);
             }
         }
         root.put(KEY_ENTRIES, encodedEntries);
@@ -88,13 +82,13 @@ final class ConfigBackupCodec {
             throw new IllegalArgumentException("Unsupported backup schema version: " + schemaVersion);
         }
         LinkedHashMap<String, Object> entries = new LinkedHashMap<>();
-        JSONObject encodedEntries = root.optJSONObject(KEY_ENTRIES);
-        if (encodedEntries != null) {
-            decodeEntrySectionInto(entries, encodedEntries);
-        }
         JSONObject encodedPackageConfigs = root.optJSONObject(KEY_PACKAGE_CONFIGS);
         if (encodedPackageConfigs != null) {
             decodePackageConfigsInto(entries, encodedPackageConfigs);
+        }
+        JSONObject encodedEntries = root.optJSONObject(KEY_ENTRIES);
+        if (encodedEntries != null) {
+            decodeEntrySectionInto(entries, encodedEntries);
         }
         if (encodedEntries == null && encodedPackageConfigs == null) {
             throw new IllegalArgumentException("Missing entries section");
@@ -124,14 +118,14 @@ final class ConfigBackupCodec {
             if (encodedValue == null) {
                 throw new IllegalArgumentException("Invalid entry payload for key: " + key);
             }
-            entries.put(key, decodeValue(encodedValue));
+            entries.put(key, decodeEntryValue(encodedValue));
         }
     }
 
-    private static boolean putEncodedPackageConfigEntry(
+    private static boolean putPackageConfigEntry(
             JSONObject encodedPackageConfigs,
             String key,
-            JSONObject encodedValue) throws JSONException {
+            Object value) throws JSONException {
         String prefix = "package_config.";
         if (!key.startsWith(prefix)) {
             return false;
@@ -150,7 +144,7 @@ final class ConfigBackupCodec {
             packageEntries = new JSONObject();
             encodedPackageConfigs.put(packageName, packageEntries);
         }
-        packageEntries.put(fieldKey, encodedValue);
+        packageEntries.put(fieldKey, value);
         return true;
     }
 
@@ -186,45 +180,38 @@ final class ConfigBackupCodec {
                 if (fieldKey == null || fieldKey.isEmpty()) {
                     continue;
                 }
-                JSONObject encodedValue = packageEntries.optJSONObject(fieldKey);
-                if (encodedValue == null) {
-                    throw new IllegalArgumentException(
-                            "Invalid package config entry for package: " + packageName
-                                    + ", key: " + fieldKey);
-                }
-                entries.put("package_config." + packageName + "." + fieldKey, decodeValue(encodedValue));
+                entries.put("package_config." + packageName + "." + fieldKey, packageEntries.get(fieldKey));
             }
         }
     }
 
-    @SuppressWarnings("unchecked")
     private static JSONObject encodeValue(Object value) throws JSONException {
         if (value == null) {
             return null;
         }
         JSONObject encoded = new JSONObject();
         if (value instanceof String typed) {
-            encoded.put(KEY_TYPE, TYPE_STRING);
+            encoded.put(KEY_TYPE, "string");
             encoded.put(KEY_VALUE, typed);
             return encoded;
         }
         if (value instanceof Integer typed) {
-            encoded.put(KEY_TYPE, TYPE_INT);
+            encoded.put(KEY_TYPE, "int");
             encoded.put(KEY_VALUE, typed);
             return encoded;
         }
         if (value instanceof Long typed) {
-            encoded.put(KEY_TYPE, TYPE_LONG);
+            encoded.put(KEY_TYPE, "long");
             encoded.put(KEY_VALUE, typed);
             return encoded;
         }
         if (value instanceof Float typed) {
-            encoded.put(KEY_TYPE, TYPE_FLOAT);
+            encoded.put(KEY_TYPE, "float");
             encoded.put(KEY_VALUE, typed);
             return encoded;
         }
         if (value instanceof Boolean typed) {
-            encoded.put(KEY_TYPE, TYPE_BOOLEAN);
+            encoded.put(KEY_TYPE, "boolean");
             encoded.put(KEY_VALUE, typed);
             return encoded;
         }
@@ -236,31 +223,27 @@ final class ConfigBackupCodec {
                 }
             }
             Collections.sort(values);
-            JSONArray array = new JSONArray();
-            for (String item : values) {
-                array.put(item);
-            }
-            encoded.put(KEY_TYPE, TYPE_STRING_SET);
-            encoded.put(KEY_VALUE, array);
+            encoded.put(KEY_TYPE, "string_set");
+            encoded.put(KEY_VALUE, values);
             return encoded;
         }
         return null;
     }
 
-    private static Object decodeValue(JSONObject encoded) throws JSONException {
+    private static Object decodeEntryValue(JSONObject encoded) throws JSONException {
         String type = encoded.optString(KEY_TYPE, "");
         return switch (type) {
-            case TYPE_STRING -> encoded.optString(KEY_VALUE, "");
-            case TYPE_INT -> encoded.getInt(KEY_VALUE);
-            case TYPE_LONG -> encoded.getLong(KEY_VALUE);
-            case TYPE_FLOAT -> (float) encoded.getDouble(KEY_VALUE);
-            case TYPE_BOOLEAN -> encoded.getBoolean(KEY_VALUE);
-            case TYPE_STRING_SET -> decodeStringSet(encoded.getJSONArray(KEY_VALUE));
+            case "string" -> encoded.optString(KEY_VALUE, "");
+            case "int" -> encoded.getInt(KEY_VALUE);
+            case "long" -> encoded.getLong(KEY_VALUE);
+            case "float" -> (float) encoded.getDouble(KEY_VALUE);
+            case "boolean" -> encoded.getBoolean(KEY_VALUE);
+            case "string_set" -> decodeStringSet(encoded.getJSONArray(KEY_VALUE));
             default -> throw new IllegalArgumentException("Unsupported backup value type: " + type);
         };
     }
 
-    private static Set<String> decodeStringSet(JSONArray array) throws JSONException {
+    private static Set<String> decodeStringSet(org.json.JSONArray array) throws JSONException {
         LinkedHashSet<String> values = new LinkedHashSet<>();
         for (int i = 0; i < array.length(); i++) {
             values.add(array.getString(i));

--- a/app/src/main/java/com/dpis/module/DpiConfigStore.java
+++ b/app/src/main/java/com/dpis/module/DpiConfigStore.java
@@ -1616,6 +1616,7 @@ final class DpiConfigStore {
     private static boolean isBackupConfigKey(String key) {
         return key != null
                 && !isBackupExcludedKey(key)
+                && !KEY_TARGET_PACKAGES.equals(key)
                 && !isLegacyPackageConfigKey(key);
     }
 

--- a/app/src/main/java/com/dpis/module/DpiConfigStore.java
+++ b/app/src/main/java/com/dpis/module/DpiConfigStore.java
@@ -799,6 +799,33 @@ final class DpiConfigStore {
         });
     }
 
+    boolean migrateLegacyPackageConfigToAggregated() {
+        LinkedHashSet<String> packages = collectLegacyPackageConfigNames(preferences.getAll());
+        if (packages.isEmpty()) {
+            return true;
+        }
+        return commitBoth(editor -> {
+            for (String packageName : packages) {
+                for (int index = 0; index < PACKAGE_CONFIG_KEYS.length; index++) {
+                    PackageConfigKeySpec legacySpec = PACKAGE_CONFIG_KEYS[index];
+                    PackageConfigKeySpec packageSpec = PACKAGE_AGGREGATED_CONFIG_KEYS[index];
+                    String legacyKey = legacySpec.keyForPackage(packageName);
+                    String packageKey = packageSpec.keyForPackage(packageName);
+                    Object legacyValue = readPrimaryPackageConfigValue(legacySpec, legacyKey);
+                    Object normalizedValue = normalizeLegacyPackageConfigValue(
+                            legacyKey,
+                            legacyValue);
+                    if (legacySpec.appliesTo(packageName)
+                            && normalizedValue != null
+                            && !preferences.contains(packageKey)) {
+                        putTypedValue(editor, packageKey, normalizedValue);
+                    }
+                }
+                removePackageConfigKeys(editor, packageName, PACKAGE_CONFIG_KEYS);
+            }
+        });
+    }
+
     boolean hasPrimaryTargetViewportWidthDp(String packageName) {
         return containsInPrimary(keyForViewportWidth(packageName));
     }
@@ -1314,6 +1341,19 @@ final class DpiConfigStore {
         return getString(key, null);
     }
 
+    private Object readPrimaryPackageConfigValue(PackageConfigKeySpec spec, String key) {
+        if (!preferences.contains(key)) {
+            return null;
+        }
+        if (spec.expectsInteger()) {
+            return readPreferenceValue(preferences, prefs -> prefs.getInt(key, 0));
+        }
+        if (spec.expectsBoolean()) {
+            return readPreferenceValue(preferences, prefs -> prefs.getBoolean(key, false));
+        }
+        return readPreferenceValue(preferences, prefs -> prefs.getString(key, null));
+    }
+
     private static boolean isRemovedKey(String key, String... removedKeys) {
         if (removedKeys == null) {
             return false;
@@ -1338,6 +1378,70 @@ final class DpiConfigStore {
                 packages.add(packageName);
             }
         }
+    }
+
+    private static LinkedHashSet<String> collectLegacyPackageConfigNames(Map<String, ?> values) {
+        LinkedHashSet<String> packages = new LinkedHashSet<>();
+        if (values == null || values.isEmpty()) {
+            return packages;
+        }
+        for (String key : values.keySet()) {
+            for (PackageConfigKeySpec spec : PACKAGE_CONFIG_KEYS) {
+                String packageName = spec.packageNameFromStorageKey(key, false);
+                if (packageName != null) {
+                    packages.add(packageName);
+                }
+            }
+        }
+        return packages;
+    }
+
+    private static Object normalizeLegacyPackageConfigValue(String key, Object value) {
+        if (key == null || value == null) {
+            return null;
+        }
+        if (key.startsWith("viewport.") && key.endsWith(".width_dp")) {
+            return value instanceof Integer intValue ? normalizeViewportWidth(intValue) : null;
+        }
+        if (key.startsWith("viewport.") && key.endsWith(".target_type")) {
+            String normalized = value instanceof String stringValue
+                    ? ViewportTargetType.normalize(stringValue)
+                    : ViewportTargetType.OFF;
+            return ViewportTargetType.OFF.equals(normalized) ? null : normalized;
+        }
+        if (key.startsWith("viewport.") && key.endsWith(".scale_permille")) {
+            return value instanceof Integer intValue
+                    ? normalizeViewportScalePermille(intValue)
+                    : null;
+        }
+        if (key.startsWith("viewport.") && key.endsWith(".mode")) {
+            String normalized = value instanceof String stringValue
+                    ? ViewportApplyMode.normalize(stringValue)
+                    : ViewportApplyMode.OFF;
+            return isConfiguredViewportModeValue(normalized) ? normalized : null;
+        }
+        if (key.startsWith("font.") && key.endsWith(".scale_percent")) {
+            return value instanceof Integer intValue ? normalizeFontScalePercent(intValue) : null;
+        }
+        if (key.startsWith("font.") && key.endsWith(".typeface_id")) {
+            return value instanceof String stringValue ? normalizeTypefaceId(stringValue) : null;
+        }
+        if (key.startsWith("font.") && key.endsWith(".mode")) {
+            String normalized = value instanceof String stringValue
+                    ? FontApplyMode.normalize(stringValue)
+                    : FontApplyMode.OFF;
+            return isConfiguredFontModeValue(normalized) ? normalized : null;
+        }
+        if (key.startsWith("font.") && key.endsWith(".hook_domains")) {
+            return value instanceof String stringValue ? normalizeNonEmptyString(stringValue) : null;
+        }
+        if (key.startsWith("target.") && key.endsWith(".dpis_enabled")) {
+            return Boolean.FALSE.equals(value) ? Boolean.FALSE : null;
+        }
+        if (key.startsWith("wechat.") && key.endsWith(".dpi")) {
+            return value instanceof Integer intValue ? WechatDpiConfig.normalize(intValue) : null;
+        }
+        return null;
     }
 
     private static String packageNameFromSavedPackageKey(String key, Object value) {
@@ -1468,7 +1572,8 @@ final class DpiConfigStore {
         if (entries == null) {
             return false;
         }
-        return replaceBackupEntries(preferences, entries);
+        return replaceBackupEntries(preferences, entries)
+                && migrateLegacyPackageConfigToAggregated();
     }
 
     private static boolean replaceBackupEntries(
@@ -1509,7 +1614,21 @@ final class DpiConfigStore {
     }
 
     private static boolean isBackupConfigKey(String key) {
-        return key != null && !isBackupExcludedKey(key);
+        return key != null
+                && !isBackupExcludedKey(key)
+                && !isLegacyPackageConfigKey(key);
+    }
+
+    private static boolean isLegacyPackageConfigKey(String key) {
+        if (key == null) {
+            return false;
+        }
+        for (PackageConfigKeySpec spec : PACKAGE_CONFIG_KEYS) {
+            if (spec.packageNameFromStorageKey(key, false) != null) {
+                return true;
+            }
+        }
+        return false;
     }
 
     private static boolean isBackupExcludedKey(String key) {
@@ -1793,6 +1912,14 @@ final class DpiConfigStore {
             return packageName != null && packagePredicate.test(packageName);
         }
 
+        String packageNameFromStorageKey(String key, boolean requireApplicablePackage) {
+            String packageName = packageNameBetween(key, prefix, suffix);
+            if (packageName == null) {
+                return null;
+            }
+            return !requireApplicablePackage || appliesTo(packageName) ? packageName : null;
+        }
+
         boolean expectsInteger() {
             return minIntValue != null && maxIntValue != null;
         }
@@ -1908,14 +2035,18 @@ final class DpiConfigStore {
     }
 
     private static String normalizeTypefaceId(String typefaceId) {
-        if (typefaceId == null) {
+        return normalizeNonEmptyString(typefaceId);
+    }
+
+    private static String normalizeNonEmptyString(String value) {
+        if (value == null) {
             return null;
         }
-        String normalizedTypefaceId = typefaceId.trim();
-        if (normalizedTypefaceId.isEmpty()) {
+        String normalizedValue = value.trim();
+        if (normalizedValue.isEmpty()) {
             return null;
         }
-        return normalizedTypefaceId;
+        return normalizedValue;
     }
 
     private static String keyForViewportWidth(String packageName) {

--- a/app/src/main/java/com/dpis/module/DpiConfigStore.java
+++ b/app/src/main/java/com/dpis/module/DpiConfigStore.java
@@ -79,6 +79,35 @@ final class DpiConfigStore {
                     DpiConfigStore::keyForWechatDpi,
                     WechatDpiConfig::appliesTo)
     };
+    private static final PackageConfigKeySpec[] PACKAGE_AGGREGATED_CONFIG_KEYS = {
+            PackageConfigKeySpec.positiveInteger("package_config.", ".viewport.width_dp",
+                    DpiConfigStore::keyForPackageViewportWidth),
+            PackageConfigKeySpec.string("package_config.", ".viewport.target_type",
+                    DpiConfigStore::keyForPackageViewportTargetType,
+                    DpiConfigStore::isConfiguredViewportTargetTypeValue),
+            PackageConfigKeySpec.rangedInteger("package_config.", ".viewport.scale_permille",
+                    MIN_VIEWPORT_SCALE_PERMILLE, MAX_VIEWPORT_SCALE_PERMILLE,
+                    DpiConfigStore::keyForPackageViewportScalePermille),
+            PackageConfigKeySpec.string("package_config.", ".viewport.mode",
+                    DpiConfigStore::keyForPackageViewportMode,
+                    DpiConfigStore::isConfiguredViewportModeValue),
+            PackageConfigKeySpec.rangedInteger("package_config.", ".font.scale_percent",
+                    MIN_FONT_SCALE_PERCENT, MAX_FONT_SCALE_PERCENT,
+                    DpiConfigStore::keyForPackageFontScale),
+            PackageConfigKeySpec.string("package_config.", ".font.typeface_id",
+                    DpiConfigStore::keyForPackageTypefaceId),
+            PackageConfigKeySpec.string("package_config.", ".font.mode",
+                    DpiConfigStore::keyForPackageFontMode,
+                    DpiConfigStore::isConfiguredFontModeValue),
+            PackageConfigKeySpec.string("package_config.", ".font.hook_domains",
+                    DpiConfigStore::keyForPackageFontHookDomains),
+            PackageConfigKeySpec.booleanValue("package_config.", ".target.dpis_enabled", false,
+                    DpiConfigStore::keyForPackageDpisEnabled),
+            PackageConfigKeySpec.rangedInteger("package_config.", ".app.wechat_dpi",
+                    WechatDpiConfig.MIN_DPI, WechatDpiConfig.MAX_DPI,
+                    DpiConfigStore::keyForPackageWechatDpi,
+                    WechatDpiConfig::appliesTo)
+    };
     private static final PackageConfigKeyFactory[] PACKAGE_TEMPLATE_CONFIG_KEYS = {
             DpiConfigStore::keyForViewportWidth,
             DpiConfigStore::keyForViewportTargetType,
@@ -88,6 +117,44 @@ final class DpiConfigStore {
             DpiConfigStore::keyForTypefaceId,
             DpiConfigStore::keyForFontMode,
             DpiConfigStore::keyForFontHookDomains
+    };
+    private static final PackageConfigKeyFactory[] PACKAGE_ALL_TEMPLATE_CONFIG_KEYS = {
+            DpiConfigStore::keyForViewportWidth,
+            DpiConfigStore::keyForViewportTargetType,
+            DpiConfigStore::keyForViewportScalePermille,
+            DpiConfigStore::keyForViewportMode,
+            DpiConfigStore::keyForFontScale,
+            DpiConfigStore::keyForTypefaceId,
+            DpiConfigStore::keyForFontMode,
+            DpiConfigStore::keyForFontHookDomains,
+            DpiConfigStore::keyForPackageViewportWidth,
+            DpiConfigStore::keyForPackageViewportTargetType,
+            DpiConfigStore::keyForPackageViewportScalePermille,
+            DpiConfigStore::keyForPackageViewportMode,
+            DpiConfigStore::keyForPackageFontScale,
+            DpiConfigStore::keyForPackageTypefaceId,
+            DpiConfigStore::keyForPackageFontMode,
+            DpiConfigStore::keyForPackageFontHookDomains
+    };
+    private static final PackageConfigKeyFactory[] PACKAGE_AGGREGATED_TEMPLATE_CONFIG_KEYS = {
+            DpiConfigStore::keyForPackageViewportWidth,
+            DpiConfigStore::keyForPackageViewportTargetType,
+            DpiConfigStore::keyForPackageViewportScalePermille,
+            DpiConfigStore::keyForPackageViewportMode,
+            DpiConfigStore::keyForPackageFontScale,
+            DpiConfigStore::keyForPackageTypefaceId,
+            DpiConfigStore::keyForPackageFontMode,
+            DpiConfigStore::keyForPackageFontHookDomains
+    };
+    private static final PackageConfigKeyFactory[] PACKAGE_ALL_VIEWPORT_CONFIG_KEYS = {
+            DpiConfigStore::keyForViewportWidth,
+            DpiConfigStore::keyForViewportTargetType,
+            DpiConfigStore::keyForViewportScalePermille,
+            DpiConfigStore::keyForViewportMode,
+            DpiConfigStore::keyForPackageViewportWidth,
+            DpiConfigStore::keyForPackageViewportTargetType,
+            DpiConfigStore::keyForPackageViewportScalePermille,
+            DpiConfigStore::keyForPackageViewportMode
     };
 
     private final SharedPreferences preferences;
@@ -125,33 +192,43 @@ final class DpiConfigStore {
 
     Integer getTargetViewportWidthDp(String packageName) {
         String key = keyForViewportWidth(packageName);
-        if (!contains(key)) {
+        String packageKey = keyForPackageViewportWidth(packageName);
+        if (!containsPackageValue(key, packageKey)) {
             return null;
         }
-        Integer widthDp = getNullableInt(key);
+        Integer widthDp = getPackageNullableInt(key, packageKey);
         return normalizeViewportWidth(widthDp);
     }
 
     Integer getTargetViewportScalePermille(String packageName) {
         String key = keyForViewportScalePermille(packageName);
-        if (!contains(key)) {
+        String packageKey = keyForPackageViewportScalePermille(packageName);
+        if (!containsPackageValue(key, packageKey)) {
             return null;
         }
-        return normalizeViewportScalePermille(getNullableInt(key));
+        return normalizeViewportScalePermille(getPackageNullableInt(key, packageKey));
     }
 
     String getTargetViewportType(String packageName) {
         String key = keyForViewportTargetType(packageName);
-        if (!contains(key)) {
+        String packageKey = keyForPackageViewportTargetType(packageName);
+        if (!containsPackageValue(key, packageKey)) {
             return ViewportTargetType.OFF;
         }
-        return ViewportTargetType.normalize(getString(key, ViewportTargetType.OFF));
+        return ViewportTargetType.normalize(getPackageString(
+                key,
+                packageKey,
+                ViewportTargetType.OFF));
     }
 
     ViewportTargetSpec getTargetViewportSpec(String packageName) {
         String typeKey = keyForViewportTargetType(packageName);
-        String type = contains(typeKey)
-                ? ViewportTargetType.normalize(getString(typeKey, ViewportTargetType.OFF))
+        String packageTypeKey = keyForPackageViewportTargetType(packageName);
+        String type = containsPackageValue(typeKey, packageTypeKey)
+                ? ViewportTargetType.normalize(getPackageString(
+                        typeKey,
+                        packageTypeKey,
+                        ViewportTargetType.OFF))
                 : ViewportTargetType.OFF;
         if (ViewportTargetType.RELATIVE_SCALE.equals(type)) {
             Integer scalePermille = getTargetViewportScalePermille(packageName);
@@ -171,11 +248,17 @@ final class DpiConfigStore {
 
     String getTargetViewportApplyMode(String packageName) {
         String key = keyForViewportMode(packageName);
-        if (contains(key)) {
-            return ViewportApplyMode.normalize(getString(key, ViewportApplyMode.OFF));
+        String packageKey = keyForPackageViewportMode(packageName);
+        if (containsPackageValue(key, packageKey)) {
+            return ViewportApplyMode.normalize(getPackageString(
+                    key,
+                    packageKey,
+                    ViewportApplyMode.OFF));
         }
         if (getTargetViewportWidthDp(packageName) != null
-                && !contains(keyForViewportTargetType(packageName))) {
+                && !containsPackageValue(
+                        keyForViewportTargetType(packageName),
+                        keyForPackageViewportTargetType(packageName))) {
             // 历史配置迁移：已有宽度但无模式时，默认视为系统策略。
             return ViewportApplyMode.SYSTEM;
         }
@@ -187,19 +270,21 @@ final class DpiConfigStore {
 
     Integer getTargetFontScalePercent(String packageName) {
         String key = keyForFontScale(packageName);
-        if (!contains(key)) {
+        String packageKey = keyForPackageFontScale(packageName);
+        if (!containsPackageValue(key, packageKey)) {
             return null;
         }
-        Integer percent = getNullableInt(key);
+        Integer percent = getPackageNullableInt(key, packageKey);
         return normalizeFontScalePercent(percent);
     }
 
     String getTargetTypefaceId(String packageName) {
         String key = keyForTypefaceId(packageName);
-        if (!contains(key)) {
+        String packageKey = keyForPackageTypefaceId(packageName);
+        if (!containsPackageValue(key, packageKey)) {
             return null;
         }
-        return normalizeTypefaceId(getString(key, null));
+        return normalizeTypefaceId(getPackageString(key, packageKey, null));
     }
 
     Integer getWechatDpi(String packageName) {
@@ -207,10 +292,11 @@ final class DpiConfigStore {
             return null;
         }
         String key = keyForWechatDpi(packageName);
-        if (!contains(key)) {
+        String packageKey = keyForPackageWechatDpi(packageName);
+        if (!containsPackageValue(key, packageKey)) {
             return null;
         }
-        return WechatDpiConfig.normalize(getNullableInt(key));
+        return WechatDpiConfig.normalize(getPackageNullableInt(key, packageKey));
     }
 
     Integer getLegacyWechatDpiForMigration() {
@@ -226,8 +312,12 @@ final class DpiConfigStore {
 
     String getTargetFontApplyMode(String packageName) {
         String key = keyForFontMode(packageName);
-        if (contains(key)) {
-            return FontApplyMode.normalize(getString(key, FontApplyMode.OFF));
+        String packageKey = keyForPackageFontMode(packageName);
+        if (containsPackageValue(key, packageKey)) {
+            return FontApplyMode.normalize(getPackageString(
+                    key,
+                    packageKey,
+                    FontApplyMode.OFF));
         }
         if (getTargetFontScalePercent(packageName) != null) {
             // 历史配置迁移：已有字体百分比但无模式时，默认视为系统模式。
@@ -398,10 +488,16 @@ final class DpiConfigStore {
         }
         LinkedHashSet<String> packages = new LinkedHashSet<>(getConfiguredPackages());
         packages.add(packageName);
-        return commitBoth(editor -> editor
-                .putStringSet(KEY_TARGET_PACKAGES, packages)
-                .putString(keyForViewportTargetType(packageName), ViewportTargetType.ABSOLUTE_DP)
-                .putInt(keyForViewportWidth(packageName), normalizedWidthDp));
+        return commitBoth(editor -> {
+            editor.putStringSet(KEY_TARGET_PACKAGES, packages);
+            removePackageViewportValueKeys(editor, packageName);
+            editor.putString(keyForViewportTargetType(packageName), ViewportTargetType.ABSOLUTE_DP);
+            editor.putString(
+                    keyForPackageViewportTargetType(packageName),
+                    ViewportTargetType.ABSOLUTE_DP);
+            editor.putInt(keyForViewportWidth(packageName), normalizedWidthDp);
+            editor.putInt(keyForPackageViewportWidth(packageName), normalizedWidthDp);
+        });
     }
 
     boolean setTargetViewportSpec(String packageName, ViewportTargetSpec spec) {
@@ -413,12 +509,18 @@ final class DpiConfigStore {
         packages.add(packageName);
         return commitBoth(editor -> {
             editor.putStringSet(KEY_TARGET_PACKAGES, packages);
+            removePackageViewportValueKeys(editor, packageName);
             editor.putString(keyForViewportTargetType(packageName), normalized.type());
+            editor.putString(keyForPackageViewportTargetType(packageName), normalized.type());
             if (normalized.isRelativeScale()) {
                 editor.putInt(keyForViewportScalePermille(packageName), normalized.scalePermille());
+                editor.putInt(
+                        keyForPackageViewportScalePermille(packageName),
+                        normalized.scalePermille());
                 return;
             }
             editor.putInt(keyForViewportWidth(packageName), normalized.absoluteWidthDp());
+            editor.putInt(keyForPackageViewportWidth(packageName), normalized.absoluteWidthDp());
         });
     }
 
@@ -431,17 +533,21 @@ final class DpiConfigStore {
         packages.add(packageName);
         return commitBoth(editor -> editor
                 .putStringSet(KEY_TARGET_PACKAGES, packages)
-                .putString(keyForViewportTargetType(packageName), normalized));
+                .putString(keyForViewportTargetType(packageName), normalized)
+                .putString(keyForPackageViewportTargetType(packageName), normalized));
     }
 
     boolean clearTargetViewportTypeDraft(String packageName) {
         LinkedHashSet<String> packages = new LinkedHashSet<>(getConfiguredPackages());
-        if (!hasAnyPackageConfigAfterRemoving(packageName, keyForViewportTargetType(packageName))) {
+        if (!hasAnyPackageConfigAfterRemoving(packageName,
+                keyForViewportTargetType(packageName),
+                keyForPackageViewportTargetType(packageName))) {
             packages.remove(packageName);
         }
         return commitBoth(editor -> editor
                 .putStringSet(KEY_TARGET_PACKAGES, packages)
-                .remove(keyForViewportTargetType(packageName)));
+                .remove(keyForViewportTargetType(packageName))
+                .remove(keyForPackageViewportTargetType(packageName)));
     }
 
     boolean setTargetViewportWidthDraft(String packageName, Integer widthDp) {
@@ -452,14 +558,16 @@ final class DpiConfigStore {
             return true;
         }
         String widthKey = keyForViewportWidth(packageName);
+        String packageWidthKey = keyForPackageViewportWidth(packageName);
         if (widthDp == null) {
             LinkedHashSet<String> packages = new LinkedHashSet<>(getConfiguredPackages());
-            if (!hasAnyPackageConfigAfterRemoving(packageName, widthKey)) {
+            if (!hasAnyPackageConfigAfterRemoving(packageName, widthKey, packageWidthKey)) {
                 packages.remove(packageName);
             }
             return commitBoth(editor -> editor
                     .putStringSet(KEY_TARGET_PACKAGES, packages)
-                    .remove(widthKey));
+                    .remove(widthKey)
+                    .remove(packageWidthKey));
         }
         Integer normalizedWidthDp = normalizeViewportWidth(widthDp);
         if (normalizedWidthDp == null) {
@@ -469,7 +577,8 @@ final class DpiConfigStore {
         packages.add(packageName);
         return commitBoth(editor -> editor
                 .putStringSet(KEY_TARGET_PACKAGES, packages)
-                .putInt(widthKey, normalizedWidthDp));
+                .putInt(widthKey, normalizedWidthDp)
+                .putInt(packageWidthKey, normalizedWidthDp));
     }
 
     boolean setTargetViewportScalePermilleDraft(String packageName, Integer scalePermille) {
@@ -480,14 +589,16 @@ final class DpiConfigStore {
             return true;
         }
         String scaleKey = keyForViewportScalePermille(packageName);
+        String packageScaleKey = keyForPackageViewportScalePermille(packageName);
         if (scalePermille == null) {
             LinkedHashSet<String> packages = new LinkedHashSet<>(getConfiguredPackages());
-            if (!hasAnyPackageConfigAfterRemoving(packageName, scaleKey)) {
+            if (!hasAnyPackageConfigAfterRemoving(packageName, scaleKey, packageScaleKey)) {
                 packages.remove(packageName);
             }
             return commitBoth(editor -> editor
                     .putStringSet(KEY_TARGET_PACKAGES, packages)
-                    .remove(scaleKey));
+                    .remove(scaleKey)
+                    .remove(packageScaleKey));
         }
         Integer normalizedScalePermille = normalizeViewportScalePermille(scalePermille);
         if (normalizedScalePermille == null) {
@@ -497,16 +608,14 @@ final class DpiConfigStore {
         packages.add(packageName);
         return commitBoth(editor -> editor
                 .putStringSet(KEY_TARGET_PACKAGES, packages)
-                .putInt(scaleKey, normalizedScalePermille));
+                .putInt(scaleKey, normalizedScalePermille)
+                .putInt(packageScaleKey, normalizedScalePermille));
     }
 
     boolean clearTargetViewportWidthDp(String packageName) {
         LinkedHashSet<String> packages = new LinkedHashSet<>(getConfiguredPackages());
         if (!hasAnyPackageConfigAfterRemoving(packageName,
-                keyForViewportWidth(packageName),
-                keyForViewportTargetType(packageName),
-                keyForViewportScalePermille(packageName),
-                keyForViewportMode(packageName))) {
+                allViewportConfigKeysForPackage(packageName))) {
             packages.remove(packageName);
         }
         return commitBoth(editor -> editor
@@ -514,7 +623,11 @@ final class DpiConfigStore {
                 .remove(keyForViewportWidth(packageName))
                 .remove(keyForViewportTargetType(packageName))
                 .remove(keyForViewportScalePermille(packageName))
-                .remove(keyForViewportMode(packageName)));
+                .remove(keyForViewportMode(packageName))
+                .remove(keyForPackageViewportWidth(packageName))
+                .remove(keyForPackageViewportTargetType(packageName))
+                .remove(keyForPackageViewportScalePermille(packageName))
+                .remove(keyForPackageViewportMode(packageName)));
     }
 
     boolean clearTargetViewportValue(String packageName) {
@@ -522,31 +635,41 @@ final class DpiConfigStore {
         if (!hasAnyPackageConfigAfterRemoving(packageName,
                 keyForViewportWidth(packageName),
                 keyForViewportScalePermille(packageName),
-                keyForViewportMode(packageName))) {
+                keyForViewportMode(packageName),
+                keyForPackageViewportWidth(packageName),
+                keyForPackageViewportScalePermille(packageName),
+                keyForPackageViewportMode(packageName))) {
             packages.remove(packageName);
         }
         return commitBoth(editor -> editor
                 .putStringSet(KEY_TARGET_PACKAGES, packages)
                 .remove(keyForViewportWidth(packageName))
                 .remove(keyForViewportScalePermille(packageName))
-                .remove(keyForViewportMode(packageName)));
+                .remove(keyForViewportMode(packageName))
+                .remove(keyForPackageViewportWidth(packageName))
+                .remove(keyForPackageViewportScalePermille(packageName))
+                .remove(keyForPackageViewportMode(packageName)));
     }
 
     boolean setTargetViewportApplyMode(String packageName, String mode) {
         String normalized = ViewportApplyMode.normalize(mode);
         LinkedHashSet<String> packages = new LinkedHashSet<>(getConfiguredPackages());
         if (!isConfiguredViewportModeValue(normalized)) {
-            if (!hasAnyPackageConfigAfterRemoving(packageName, keyForViewportMode(packageName))) {
+            if (!hasAnyPackageConfigAfterRemoving(packageName,
+                    keyForViewportMode(packageName),
+                    keyForPackageViewportMode(packageName))) {
                 packages.remove(packageName);
             }
             return commitBoth(editor -> editor
                     .putStringSet(KEY_TARGET_PACKAGES, packages)
-                    .remove(keyForViewportMode(packageName)));
+                    .remove(keyForViewportMode(packageName))
+                    .remove(keyForPackageViewportMode(packageName)));
         }
         packages.add(packageName);
         return commitBoth(editor -> editor
                 .putStringSet(KEY_TARGET_PACKAGES, packages)
-                .putString(keyForViewportMode(packageName), normalized));
+                .putString(keyForViewportMode(packageName), normalized)
+                .putString(keyForPackageViewportMode(packageName), normalized));
     }
 
     boolean setTargetFontScalePercent(String packageName, int percent) {
@@ -558,7 +681,8 @@ final class DpiConfigStore {
         packages.add(packageName);
         return commitBoth(editor -> editor
                 .putStringSet(KEY_TARGET_PACKAGES, packages)
-                .putInt(keyForFontScale(packageName), normalizedPercent));
+                .putInt(keyForFontScale(packageName), normalizedPercent)
+                .putInt(keyForPackageFontScale(packageName), normalizedPercent));
     }
 
     boolean setTargetTypefaceId(String packageName, String typefaceId) {
@@ -570,7 +694,8 @@ final class DpiConfigStore {
         packages.add(packageName);
         return commitBoth(editor -> editor
                 .putStringSet(KEY_TARGET_PACKAGES, packages)
-                .putString(keyForTypefaceId(packageName), normalizedTypefaceId));
+                .putString(keyForTypefaceId(packageName), normalizedTypefaceId)
+                .putString(keyForPackageTypefaceId(packageName), normalizedTypefaceId));
     }
 
     boolean setWechatDpi(String packageName, Integer dpi) {
@@ -585,44 +710,55 @@ final class DpiConfigStore {
         packages.add(packageName);
         return commitBoth(editor -> editor
                 .putStringSet(KEY_TARGET_PACKAGES, packages)
-                .putInt(keyForWechatDpi(packageName), normalized));
+                .putInt(keyForWechatDpi(packageName), normalized)
+                .putInt(keyForPackageWechatDpi(packageName), normalized));
     }
 
     boolean setTargetFontApplyMode(String packageName, String mode) {
         String normalized = FontApplyMode.normalize(mode);
         LinkedHashSet<String> packages = new LinkedHashSet<>(getConfiguredPackages());
         if (!isConfiguredFontModeValue(normalized)) {
-            if (!hasAnyPackageConfigAfterRemoving(packageName, keyForFontMode(packageName))) {
+            if (!hasAnyPackageConfigAfterRemoving(packageName,
+                    keyForFontMode(packageName),
+                    keyForPackageFontMode(packageName))) {
                 packages.remove(packageName);
             }
             return commitBoth(editor -> editor
                     .putStringSet(KEY_TARGET_PACKAGES, packages)
-                    .remove(keyForFontMode(packageName)));
+                    .remove(keyForFontMode(packageName))
+                    .remove(keyForPackageFontMode(packageName)));
         }
         packages.add(packageName);
         return commitBoth(editor -> editor
                 .putStringSet(KEY_TARGET_PACKAGES, packages)
-                .putString(keyForFontMode(packageName), normalized));
+                .putString(keyForFontMode(packageName), normalized)
+                .putString(keyForPackageFontMode(packageName), normalized));
     }
 
     boolean clearTargetFontScalePercent(String packageName) {
         LinkedHashSet<String> packages = new LinkedHashSet<>(getConfiguredPackages());
-        if (!hasAnyPackageConfigAfterRemoving(packageName, keyForFontScale(packageName))) {
+        if (!hasAnyPackageConfigAfterRemoving(packageName,
+                keyForFontScale(packageName),
+                keyForPackageFontScale(packageName))) {
             packages.remove(packageName);
         }
         return commitBoth(editor -> editor
                 .putStringSet(KEY_TARGET_PACKAGES, packages)
-                .remove(keyForFontScale(packageName)));
+                .remove(keyForFontScale(packageName))
+                .remove(keyForPackageFontScale(packageName)));
     }
 
     boolean clearTargetTypefaceId(String packageName) {
         LinkedHashSet<String> packages = new LinkedHashSet<>(getConfiguredPackages());
-        if (!hasAnyPackageConfigAfterRemoving(packageName, keyForTypefaceId(packageName))) {
+        if (!hasAnyPackageConfigAfterRemoving(packageName,
+                keyForTypefaceId(packageName),
+                keyForPackageTypefaceId(packageName))) {
             packages.remove(packageName);
         }
         return commitBoth(editor -> editor
                 .putStringSet(KEY_TARGET_PACKAGES, packages)
-                .remove(keyForTypefaceId(packageName)));
+                .remove(keyForTypefaceId(packageName))
+                .remove(keyForPackageTypefaceId(packageName)));
     }
 
     boolean clearWechatDpi(String packageName) {
@@ -630,12 +766,15 @@ final class DpiConfigStore {
             return true;
         }
         LinkedHashSet<String> packages = new LinkedHashSet<>(getConfiguredPackages());
-        if (!hasAnyPackageConfigAfterRemoving(packageName, keyForWechatDpi(packageName))) {
+        if (!hasAnyPackageConfigAfterRemoving(packageName,
+                keyForWechatDpi(packageName),
+                keyForPackageWechatDpi(packageName))) {
             packages.remove(packageName);
         }
         return commitBoth(editor -> editor
                 .putStringSet(KEY_TARGET_PACKAGES, packages)
-                .remove(keyForWechatDpi(packageName)));
+                .remove(keyForWechatDpi(packageName))
+                .remove(keyForPackageWechatDpi(packageName)));
     }
 
     boolean migrateLegacyWechatDpi() {
@@ -656,6 +795,7 @@ final class DpiConfigStore {
             editor.putStringSet(KEY_TARGET_PACKAGES, packages)
                     .remove(LEGACY_WECHAT_DPI_KEY);
             editor.putInt(officialKey, legacyDpi);
+            editor.putInt(keyForPackageWechatDpi(WechatDpiConfig.PACKAGE_NAME), legacyDpi);
         });
     }
 
@@ -680,23 +820,30 @@ final class DpiConfigStore {
     }
 
     boolean isTargetDpisEnabled(String packageName) {
-        return getBoolean(keyForDpisEnabled(packageName), true);
+        return getPackageBoolean(
+                keyForDpisEnabled(packageName),
+                keyForPackageDpisEnabled(packageName),
+                true);
     }
 
     boolean setTargetDpisEnabled(String packageName, boolean enabled) {
         LinkedHashSet<String> packages = new LinkedHashSet<>(getConfiguredPackages());
         if (enabled) {
-            if (!hasAnyPackageConfigAfterRemoving(packageName, keyForDpisEnabled(packageName))) {
+            if (!hasAnyPackageConfigAfterRemoving(packageName,
+                    keyForDpisEnabled(packageName),
+                    keyForPackageDpisEnabled(packageName))) {
                 packages.remove(packageName);
             }
             return commitBoth(editor -> editor
                     .putStringSet(KEY_TARGET_PACKAGES, packages)
-                    .remove(keyForDpisEnabled(packageName)));
+                    .remove(keyForDpisEnabled(packageName))
+                    .remove(keyForPackageDpisEnabled(packageName)));
         }
         packages.add(packageName);
         return commitBoth(editor -> editor
                 .putStringSet(KEY_TARGET_PACKAGES, packages)
-                .putBoolean(keyForDpisEnabled(packageName), false));
+                .putBoolean(keyForDpisEnabled(packageName), false)
+                .putBoolean(keyForPackageDpisEnabled(packageName), false));
     }
 
     boolean clearTargetPackageConfig(String packageName) {
@@ -705,6 +852,7 @@ final class DpiConfigStore {
         return commitBoth(editor -> {
             editor.putStringSet(KEY_TARGET_PACKAGES, packages);
             removePackageConfigKeys(editor, packageName, PACKAGE_CONFIG_KEYS);
+            removePackageConfigKeys(editor, packageName, PACKAGE_AGGREGATED_CONFIG_KEYS);
         });
     }
 
@@ -723,10 +871,11 @@ final class DpiConfigStore {
             return null;
         }
         String key = keyForFontHookDomains(packageName);
-        if (!contains(key)) {
+        String packageKey = keyForPackageFontHookDomains(packageName);
+        if (!containsPackageValue(key, packageKey)) {
             return null;
         }
-        return getString(key, null);
+        return getPackageString(key, packageKey, null);
     }
 
     boolean setPackageFontHookDomainsRaw(String packageName, String rawValue) {
@@ -737,7 +886,8 @@ final class DpiConfigStore {
         packages.add(packageName);
         return commitBoth(editor -> editor
                 .putStringSet(KEY_TARGET_PACKAGES, packages)
-                .putString(keyForFontHookDomains(packageName), rawValue));
+                .putString(keyForFontHookDomains(packageName), rawValue)
+                .putString(keyForPackageFontHookDomains(packageName), rawValue));
     }
 
     boolean clearPackageFontHookDomainsRaw(String packageName) {
@@ -745,12 +895,15 @@ final class DpiConfigStore {
             return false;
         }
         LinkedHashSet<String> packages = new LinkedHashSet<>(getConfiguredPackages());
-        if (!hasAnyPackageConfigAfterRemoving(packageName, keyForFontHookDomains(packageName))) {
+        if (!hasAnyPackageConfigAfterRemoving(packageName,
+                keyForFontHookDomains(packageName),
+                keyForPackageFontHookDomains(packageName))) {
             packages.remove(packageName);
         }
         return commitBoth(editor -> editor
                 .putStringSet(KEY_TARGET_PACKAGES, packages)
-                .remove(keyForFontHookDomains(packageName)));
+                .remove(keyForFontHookDomains(packageName))
+                .remove(keyForPackageFontHookDomains(packageName)));
     }
 
     boolean hasRealPackageConfig(String packageName) {
@@ -767,17 +920,185 @@ final class DpiConfigStore {
         return hasAnyPackageConfigAfterRemoving(packageName);
     }
 
+    PackageConfigValue readPackageConfig(String packageName) {
+        if (packageName == null || packageName.isBlank()) {
+            return PackageConfigValue.EMPTY;
+        }
+        return new PackageConfigValue(
+                getPackageViewportSpec(packageName),
+                containsPackageValue(
+                        keyForViewportTargetType(packageName),
+                        keyForPackageViewportTargetType(packageName))
+                        ? ViewportTargetType.normalize(getPackageString(
+                                keyForViewportTargetType(packageName),
+                                keyForPackageViewportTargetType(packageName),
+                                ViewportTargetType.OFF))
+                        : ViewportTargetType.OFF,
+                containsPackageValue(
+                        keyForViewportMode(packageName),
+                        keyForPackageViewportMode(packageName))
+                        ? ViewportApplyMode.normalize(getPackageString(
+                                keyForViewportMode(packageName),
+                                keyForPackageViewportMode(packageName),
+                                ViewportApplyMode.OFF))
+                        : ViewportApplyMode.OFF,
+                containsPackageValue(
+                        keyForFontScale(packageName),
+                        keyForPackageFontScale(packageName))
+                        ? normalizeFontScalePercent(getPackageNullableInt(
+                                keyForFontScale(packageName),
+                                keyForPackageFontScale(packageName)))
+                        : null,
+                containsPackageValue(
+                        keyForFontMode(packageName),
+                        keyForPackageFontMode(packageName))
+                        ? FontApplyMode.normalize(getPackageString(
+                                keyForFontMode(packageName),
+                                keyForPackageFontMode(packageName),
+                                FontApplyMode.OFF))
+                        : FontApplyMode.OFF,
+                normalizeTypefaceId(getPackageString(
+                        keyForTypefaceId(packageName),
+                        keyForPackageTypefaceId(packageName),
+                        null)),
+                getPackageString(
+                        keyForFontHookDomains(packageName),
+                        keyForPackageFontHookDomains(packageName),
+                        null),
+                containsPackageValue(
+                        keyForDpisEnabled(packageName),
+                        keyForPackageDpisEnabled(packageName))
+                        ? Boolean.valueOf(getPackageBoolean(
+                                keyForDpisEnabled(packageName),
+                                keyForPackageDpisEnabled(packageName),
+                                true))
+                        : null,
+                WechatDpiConfig.appliesTo(packageName)
+                        ? WechatDpiConfig.normalize(getPackageNullableInt(
+                                keyForWechatDpi(packageName),
+                                keyForPackageWechatDpi(packageName)))
+                        : null);
+    }
+
+    private ViewportTargetSpec getPackageViewportSpec(String packageName) {
+        String type = containsPackageValue(
+                keyForViewportTargetType(packageName),
+                keyForPackageViewportTargetType(packageName))
+                ? ViewportTargetType.normalize(getPackageString(
+                        keyForViewportTargetType(packageName),
+                        keyForPackageViewportTargetType(packageName),
+                        ViewportTargetType.OFF))
+                : ViewportTargetType.OFF;
+        if (ViewportTargetType.RELATIVE_SCALE.equals(type)) {
+            Integer scalePermille = normalizeViewportScalePermille(getPackageNullableInt(
+                    keyForViewportScalePermille(packageName),
+                    keyForPackageViewportScalePermille(packageName)));
+            return scalePermille != null
+                    ? ViewportTargetSpec.relativeScale(scalePermille)
+                    : ViewportTargetSpec.off();
+        }
+        if (ViewportTargetType.ABSOLUTE_DP.equals(type)) {
+            Integer widthDp = normalizeViewportWidth(getPackageNullableInt(
+                    keyForViewportWidth(packageName),
+                    keyForPackageViewportWidth(packageName)));
+            return widthDp != null ? ViewportTargetSpec.absoluteDp(widthDp) : ViewportTargetSpec.off();
+        }
+        Integer legacyWidthDp = normalizeViewportWidth(getPackageNullableInt(
+                keyForViewportWidth(packageName),
+                keyForPackageViewportWidth(packageName)));
+        return legacyWidthDp != null
+                ? ViewportTargetSpec.absoluteDp(legacyWidthDp)
+                : ViewportTargetSpec.off();
+    }
+
+    boolean writePackageConfig(String packageName, PackageConfigValue value) {
+        if (packageName == null || packageName.isBlank()) {
+            return false;
+        }
+        PackageConfigValue normalized = value != null ? value : PackageConfigValue.EMPTY;
+        LinkedHashSet<String> packages = new LinkedHashSet<>(getConfiguredPackages());
+        if (normalized.hasAnyValue()) {
+            packages.add(packageName);
+        } else if (!hasAnyPackageConfigAfterRemoving(
+                packageName,
+                packageConfigKeysForPackage(packageName))) {
+            packages.remove(packageName);
+        }
+        return commitBoth(editor -> {
+            editor.putStringSet(KEY_TARGET_PACKAGES, packages);
+            removePackageConfigKeys(editor, packageName, PACKAGE_CONFIG_KEYS);
+            removePackageConfigKeys(editor, packageName, PACKAGE_AGGREGATED_CONFIG_KEYS);
+            if (normalized.viewportTargetSpec.isEnabled()) {
+                editor.putString(
+                        keyForViewportTargetType(packageName),
+                        normalized.viewportTargetSpec.type());
+                editor.putString(
+                        keyForPackageViewportTargetType(packageName),
+                        normalized.viewportTargetSpec.type());
+                if (normalized.viewportTargetSpec.isRelativeScale()) {
+                    editor.putInt(
+                            keyForViewportScalePermille(packageName),
+                            normalized.viewportTargetSpec.scalePermille());
+                    editor.putInt(
+                            keyForPackageViewportScalePermille(packageName),
+                            normalized.viewportTargetSpec.scalePermille());
+                } else {
+                    editor.putInt(
+                            keyForViewportWidth(packageName),
+                            normalized.viewportTargetSpec.absoluteWidthDp());
+                    editor.putInt(
+                            keyForPackageViewportWidth(packageName),
+                            normalized.viewportTargetSpec.absoluteWidthDp());
+                }
+            } else if (!ViewportTargetType.OFF.equals(normalized.viewportTargetType)) {
+                editor.putString(
+                        keyForViewportTargetType(packageName),
+                        normalized.viewportTargetType);
+                editor.putString(
+                        keyForPackageViewportTargetType(packageName),
+                        normalized.viewportTargetType);
+            }
+            if (isConfiguredViewportModeValue(normalized.viewportApplyMode)) {
+                editor.putString(keyForViewportMode(packageName), normalized.viewportApplyMode);
+                editor.putString(
+                        keyForPackageViewportMode(packageName),
+                        normalized.viewportApplyMode);
+            }
+            if (normalized.fontScalePercent != null) {
+                editor.putInt(keyForFontScale(packageName), normalized.fontScalePercent);
+                editor.putInt(keyForPackageFontScale(packageName), normalized.fontScalePercent);
+            }
+            if (isConfiguredFontModeValue(normalized.fontApplyMode)) {
+                editor.putString(keyForFontMode(packageName), normalized.fontApplyMode);
+                editor.putString(keyForPackageFontMode(packageName), normalized.fontApplyMode);
+            }
+            if (normalized.typefaceId != null) {
+                editor.putString(keyForTypefaceId(packageName), normalized.typefaceId);
+                editor.putString(keyForPackageTypefaceId(packageName), normalized.typefaceId);
+            }
+            if (normalized.fontHookDomainsRaw != null) {
+                editor.putString(keyForFontHookDomains(packageName), normalized.fontHookDomainsRaw);
+                editor.putString(
+                        keyForPackageFontHookDomains(packageName),
+                        normalized.fontHookDomainsRaw);
+            }
+            if (Boolean.FALSE.equals(normalized.dpisEnabled)) {
+                editor.putBoolean(keyForDpisEnabled(packageName), false);
+                editor.putBoolean(keyForPackageDpisEnabled(packageName), false);
+            }
+            if (normalized.wechatDpi != null && WechatDpiConfig.appliesTo(packageName)) {
+                editor.putInt(keyForWechatDpi(packageName), normalized.wechatDpi);
+                editor.putInt(keyForPackageWechatDpi(packageName), normalized.wechatDpi);
+            }
+        });
+    }
+
     TemplateConfigValue readPackageTemplateConfigValue(String packageName) {
         if (packageName == null || packageName.isBlank()) {
             return TemplateConfigValue.EMPTY;
         }
-        return new TemplateConfigValue(
-                getTargetViewportSpec(packageName),
-                getTargetViewportApplyMode(packageName),
-                getTargetFontScalePercent(packageName),
-                getTargetFontApplyMode(packageName),
-                getTargetTypefaceId(packageName),
-                getPackageFontHookDomainsRaw(packageName));
+        return templateConfigValueFromPackageConfig(
+                readPackageConfig(packageName));
     }
 
     boolean writePackageTemplateConfigValue(String packageName, TemplateConfigValue value) {
@@ -785,9 +1106,12 @@ final class DpiConfigStore {
             return false;
         }
         TemplateConfigValue normalized = value != null ? value : TemplateConfigValue.EMPTY;
+        PackageConfigValue copyableConfig = packageConfigValueFromTemplateConfigValue(normalized);
         if (!normalized.hasAnyValue()) {
             LinkedHashSet<String> packages = new LinkedHashSet<>(getConfiguredPackages());
-            if (hasAnyPackageConfigAfterRemoving(packageName, templateConfigKeysForPackage(packageName))) {
+            if (hasAnyPackageConfigAfterRemoving(
+                    packageName,
+                    allTemplateConfigKeysForPackage(packageName))) {
                 packages.add(packageName);
             } else {
                 packages.remove(packageName);
@@ -795,6 +1119,7 @@ final class DpiConfigStore {
             return commitBoth(editor -> {
                 editor.putStringSet(KEY_TARGET_PACKAGES, packages);
                 removePackageTemplateConfigKeys(editor, packageName);
+                removePackageAggregatedTemplateConfigKeys(editor, packageName);
             });
         }
         LinkedHashSet<String> packages = new LinkedHashSet<>(getConfiguredPackages());
@@ -802,36 +1127,89 @@ final class DpiConfigStore {
         return commitBoth(editor -> {
             editor.putStringSet(KEY_TARGET_PACKAGES, packages);
             removePackageTemplateConfigKeys(editor, packageName);
-            if (normalized.viewportTargetSpec.isEnabled()) {
+            removePackageAggregatedTemplateConfigKeys(editor, packageName);
+            if (copyableConfig.viewportTargetSpec.isEnabled()) {
                 editor.putString(
                         keyForViewportTargetType(packageName),
-                        normalized.viewportTargetSpec.type());
-                if (normalized.viewportTargetSpec.isRelativeScale()) {
+                        copyableConfig.viewportTargetSpec.type());
+                editor.putString(
+                        keyForPackageViewportTargetType(packageName),
+                        copyableConfig.viewportTargetSpec.type());
+                if (copyableConfig.viewportTargetSpec.isRelativeScale()) {
                     editor.putInt(
                             keyForViewportScalePermille(packageName),
-                            normalized.viewportTargetSpec.scalePermille());
+                            copyableConfig.viewportTargetSpec.scalePermille());
+                    editor.putInt(
+                            keyForPackageViewportScalePermille(packageName),
+                            copyableConfig.viewportTargetSpec.scalePermille());
                 } else {
                     editor.putInt(
                             keyForViewportWidth(packageName),
-                            normalized.viewportTargetSpec.absoluteWidthDp());
+                            copyableConfig.viewportTargetSpec.absoluteWidthDp());
+                    editor.putInt(
+                            keyForPackageViewportWidth(packageName),
+                            copyableConfig.viewportTargetSpec.absoluteWidthDp());
                 }
             }
-            if (ViewportApplyMode.isEnabled(normalized.viewportApplyMode)) {
-                editor.putString(keyForViewportMode(packageName), normalized.viewportApplyMode);
+            if (ViewportApplyMode.isEnabled(copyableConfig.viewportApplyMode)) {
+                editor.putString(
+                        keyForViewportMode(packageName),
+                        copyableConfig.viewportApplyMode);
+                editor.putString(
+                        keyForPackageViewportMode(packageName),
+                        copyableConfig.viewportApplyMode);
             }
-            if (normalized.fontScalePercent != null) {
-                editor.putInt(keyForFontScale(packageName), normalized.fontScalePercent);
+            if (copyableConfig.fontScalePercent != null) {
+                editor.putInt(keyForFontScale(packageName), copyableConfig.fontScalePercent);
+                editor.putInt(
+                        keyForPackageFontScale(packageName),
+                        copyableConfig.fontScalePercent);
             }
-            if (FontApplyMode.isEnabled(normalized.fontApplyMode)) {
-                editor.putString(keyForFontMode(packageName), normalized.fontApplyMode);
+            if (FontApplyMode.isEnabled(copyableConfig.fontApplyMode)) {
+                editor.putString(keyForFontMode(packageName), copyableConfig.fontApplyMode);
+                editor.putString(keyForPackageFontMode(packageName), copyableConfig.fontApplyMode);
             }
-            if (normalized.typefaceId != null) {
-                editor.putString(keyForTypefaceId(packageName), normalized.typefaceId);
+            if (copyableConfig.typefaceId != null) {
+                editor.putString(keyForTypefaceId(packageName), copyableConfig.typefaceId);
+                editor.putString(keyForPackageTypefaceId(packageName), copyableConfig.typefaceId);
             }
-            if (normalized.fontHookDomainsRaw != null) {
-                editor.putString(keyForFontHookDomains(packageName), normalized.fontHookDomainsRaw);
+            if (copyableConfig.fontHookDomainsRaw != null) {
+                editor.putString(
+                        keyForFontHookDomains(packageName),
+                        copyableConfig.fontHookDomainsRaw);
+                editor.putString(
+                        keyForPackageFontHookDomains(packageName),
+                        copyableConfig.fontHookDomainsRaw);
             }
         });
+    }
+
+    private static TemplateConfigValue templateConfigValueFromPackageConfig(
+            PackageConfigValue value) {
+        PackageConfigValue normalized = value != null ? value : PackageConfigValue.EMPTY;
+        return new TemplateConfigValue(
+                normalized.viewportTargetSpec,
+                normalized.viewportTargetType,
+                normalized.viewportApplyMode,
+                normalized.fontScalePercent,
+                normalized.fontApplyMode,
+                normalized.typefaceId,
+                normalized.fontHookDomainsRaw);
+    }
+
+    private static PackageConfigValue packageConfigValueFromTemplateConfigValue(
+            TemplateConfigValue value) {
+        TemplateConfigValue normalized = value != null ? value : TemplateConfigValue.EMPTY;
+        return new PackageConfigValue(
+                normalized.viewportTargetSpec,
+                normalized.viewportTargetType,
+                normalized.viewportApplyMode,
+                normalized.fontScalePercent,
+                normalized.fontApplyMode,
+                normalized.typefaceId,
+                normalized.fontHookDomainsRaw,
+                null,
+                null);
     }
 
     private static void removePackageTemplateConfigKeys(
@@ -842,12 +1220,72 @@ final class DpiConfigStore {
         }
     }
 
+    private static void removePackageAggregatedTemplateConfigKeys(
+            SharedPreferences.Editor editor,
+            String packageName) {
+        for (String key : aggregatedTemplateConfigKeysForPackage(packageName)) {
+            editor.remove(key);
+        }
+    }
+
+    private static void removePackageViewportConfigKeys(
+            SharedPreferences.Editor editor,
+            String packageName) {
+        for (String key : allViewportConfigKeysForPackage(packageName)) {
+            editor.remove(key);
+        }
+    }
+
+    private static void removePackageViewportValueKeys(
+            SharedPreferences.Editor editor,
+            String packageName) {
+        editor.remove(keyForViewportWidth(packageName))
+                .remove(keyForViewportScalePermille(packageName))
+                .remove(keyForPackageViewportWidth(packageName))
+                .remove(keyForPackageViewportScalePermille(packageName));
+    }
+
     private static String[] templateConfigKeysForPackage(String packageName) {
         return keysForPackage(packageName, PACKAGE_TEMPLATE_CONFIG_KEYS);
     }
 
-    private boolean hasAnyPackageConfigAfterRemoving(String packageName, String... removedKeys) {
+    private static String[] aggregatedTemplateConfigKeysForPackage(String packageName) {
+        return keysForPackage(packageName, PACKAGE_AGGREGATED_TEMPLATE_CONFIG_KEYS);
+    }
+
+    private static String[] allTemplateConfigKeysForPackage(String packageName) {
+        return keysForPackage(packageName, PACKAGE_ALL_TEMPLATE_CONFIG_KEYS);
+    }
+
+    private static String[] allViewportConfigKeysForPackage(String packageName) {
+        return keysForPackage(packageName, PACKAGE_ALL_VIEWPORT_CONFIG_KEYS);
+    }
+
+    private static String[] packageConfigKeysForPackage(String packageName) {
+        String[] keys = new String[PACKAGE_CONFIG_KEYS.length + PACKAGE_AGGREGATED_CONFIG_KEYS.length];
+        int index = 0;
         for (PackageConfigKeySpec spec : PACKAGE_CONFIG_KEYS) {
+            keys[index++] = spec.keyForPackage(packageName);
+        }
+        for (PackageConfigKeySpec spec : PACKAGE_AGGREGATED_CONFIG_KEYS) {
+            keys[index++] = spec.keyForPackage(packageName);
+        }
+        return keys;
+    }
+
+    private boolean hasAnyPackageConfigAfterRemoving(String packageName, String... removedKeys) {
+        return hasAnyPackageConfigAfterRemoving(PACKAGE_CONFIG_KEYS, packageName, removedKeys)
+                || hasAnyPackageConfigAfterRemoving(
+                        PACKAGE_AGGREGATED_CONFIG_KEYS,
+                        packageName,
+                        removedKeys);
+    }
+
+    private boolean hasAnyPackageConfigAfterRemoving(
+            PackageConfigKeySpec[] specs,
+            String packageName,
+            String... removedKeys) {
+        for (PackageConfigKeySpec spec : specs) {
             String key = spec.keyForPackage(packageName);
             if (!isRemovedKey(key, removedKeys) && hasConfiguredValue(spec, packageName, key)) {
                 return true;
@@ -907,6 +1345,12 @@ final class DpiConfigStore {
             return null;
         }
         for (PackageConfigKeySpec spec : PACKAGE_CONFIG_KEYS) {
+            String packageName = spec.packageNameFromKey(key, value);
+            if (packageName != null) {
+                return packageName;
+            }
+        }
+        for (PackageConfigKeySpec spec : PACKAGE_AGGREGATED_CONFIG_KEYS) {
             String packageName = spec.packageNameFromKey(key, value);
             if (packageName != null) {
                 return packageName;
@@ -1103,6 +1547,10 @@ final class DpiConfigStore {
                 || (fallbackPreferences != null && fallbackPreferences.contains(key));
     }
 
+    private boolean containsPackageValue(String legacyKey, String packageKey) {
+        return contains(legacyKey) || contains(packageKey);
+    }
+
     private boolean containsInPrimary(String key) {
         return preferences.contains(key);
     }
@@ -1129,9 +1577,23 @@ final class DpiConfigStore {
         return value != null ? value : defaultValue;
     }
 
+    private String getPackageString(String legacyKey, String packageKey, String defaultValue) {
+        if (contains(legacyKey)) {
+            return getString(legacyKey, defaultValue);
+        }
+        return getString(packageKey, defaultValue);
+    }
+
     private boolean getBoolean(String key, boolean defaultValue) {
         Boolean value = readPreferenceValue(key, prefs -> prefs.getBoolean(key, defaultValue));
         return value != null ? value : defaultValue;
+    }
+
+    private boolean getPackageBoolean(String legacyKey, String packageKey, boolean defaultValue) {
+        if (contains(legacyKey)) {
+            return getBoolean(legacyKey, defaultValue);
+        }
+        return getBoolean(packageKey, defaultValue);
     }
 
     private boolean getLocalOnlyBoolean(String key, boolean defaultValue) {
@@ -1144,6 +1606,13 @@ final class DpiConfigStore {
 
     private Integer getNullableInt(String key) {
         return readPreferenceValue(key, prefs -> prefs.getInt(key, 0));
+    }
+
+    private Integer getPackageNullableInt(String legacyKey, String packageKey) {
+        if (contains(legacyKey)) {
+            return getNullableInt(legacyKey);
+        }
+        return getNullableInt(packageKey);
     }
 
     private <T> T readPreferenceValue(String key, PreferenceReader<T> reader) {
@@ -1453,39 +1922,79 @@ final class DpiConfigStore {
         return "viewport." + packageName + ".width_dp";
     }
 
+    private static String keyForPackageViewportWidth(String packageName) {
+        return "package_config." + packageName + ".viewport.width_dp";
+    }
+
     private static String keyForViewportTargetType(String packageName) {
         return "viewport." + packageName + ".target_type";
+    }
+
+    private static String keyForPackageViewportTargetType(String packageName) {
+        return "package_config." + packageName + ".viewport.target_type";
     }
 
     private static String keyForViewportScalePermille(String packageName) {
         return "viewport." + packageName + ".scale_permille";
     }
 
+    private static String keyForPackageViewportScalePermille(String packageName) {
+        return "package_config." + packageName + ".viewport.scale_permille";
+    }
+
     private static String keyForViewportMode(String packageName) {
         return "viewport." + packageName + ".mode";
+    }
+
+    private static String keyForPackageViewportMode(String packageName) {
+        return "package_config." + packageName + ".viewport.mode";
     }
 
     private static String keyForFontScale(String packageName) {
         return "font." + packageName + ".scale_percent";
     }
 
+    private static String keyForPackageFontScale(String packageName) {
+        return "package_config." + packageName + ".font.scale_percent";
+    }
+
     private static String keyForTypefaceId(String packageName) {
         return "font." + packageName + ".typeface_id";
+    }
+
+    private static String keyForPackageTypefaceId(String packageName) {
+        return "package_config." + packageName + ".font.typeface_id";
     }
 
     private static String keyForFontMode(String packageName) {
         return "font." + packageName + ".mode";
     }
 
+    private static String keyForPackageFontMode(String packageName) {
+        return "package_config." + packageName + ".font.mode";
+    }
+
     private static String keyForDpisEnabled(String packageName) {
         return "target." + packageName + ".dpis_enabled";
+    }
+
+    private static String keyForPackageDpisEnabled(String packageName) {
+        return "package_config." + packageName + ".target.dpis_enabled";
     }
 
     private static String keyForFontHookDomains(String packageName) {
         return "font." + packageName + ".hook_domains";
     }
 
+    private static String keyForPackageFontHookDomains(String packageName) {
+        return "package_config." + packageName + ".font.hook_domains";
+    }
+
     private static String keyForWechatDpi(String packageName) {
         return "wechat." + packageName + ".dpi";
+    }
+
+    private static String keyForPackageWechatDpi(String packageName) {
+        return "package_config." + packageName + ".app.wechat_dpi";
     }
 }

--- a/app/src/main/java/com/dpis/module/DpisApplication.java
+++ b/app/src/main/java/com/dpis/module/DpisApplication.java
@@ -37,7 +37,7 @@ public final class DpisApplication extends Application implements XposedServiceH
         DynamicColors.applyToActivitiesIfAvailable(this);
         HyperOsNativeProxyAssetExporter.exportBundledNativeProxyLibrary(this);
         configStore = ConfigStoreFactory.createLocalModuleConfigStore(this);
-        configStore.migrateLegacyWechatDpi();
+        migrateLocalConfigStore(configStore);
         DpisLog.setLoggingEnabled(configStore.isGlobalLogEnabled());
         RuntimePropertyRecoveryCoordinator.resyncConfiguredTargetsAsync(configStore);
         XposedServiceHelper.registerListener(this);
@@ -49,7 +49,7 @@ public final class DpisApplication extends Application implements XposedServiceH
         DpiConfigStore localStore = ConfigStoreFactory.createLocalModuleConfigStore(this);
         DpiConfigStore runtimeDeliveryStore =
                 ConfigStoreFactory.createRuntimeDeliveryModuleConfigStore(service);
-        localStore.migrateLegacyWechatDpi();
+        migrateLocalConfigStore(localStore);
         publishRuntimeConfig(localStore, runtimeDeliveryStore);
         configStore = ConfigStoreFactory.createLocalUiModuleConfigStore(this, service);
         DpisLog.setLoggingEnabled(configStore.isGlobalLogEnabled());
@@ -115,6 +115,7 @@ public final class DpisApplication extends Application implements XposedServiceH
         }
         XposedService service = xposedService;
         DpiConfigStore localStore = ConfigStoreFactory.createLocalModuleConfigStore(application);
+        migrateLocalConfigStore(localStore);
         publishRuntimeConfig(localStore,
                 ConfigStoreFactory.createRuntimeDeliveryModuleConfigStore(service));
         DpiConfigStore refreshedStore = service != null
@@ -141,6 +142,14 @@ public final class DpisApplication extends Application implements XposedServiceH
         for (ServiceStateListener listener : SERVICE_STATE_LISTENERS) {
             listener.onServiceStateChanged();
         }
+    }
+
+    private static void migrateLocalConfigStore(DpiConfigStore store) {
+        if (store == null) {
+            return;
+        }
+        store.migrateLegacyWechatDpi();
+        store.migrateLegacyPackageConfigToAggregated();
     }
 
     private static void publishRuntimeConfig(DpiConfigStore from, DpiConfigStore to) {

--- a/app/src/main/java/com/dpis/module/PackageConfigRepository.java
+++ b/app/src/main/java/com/dpis/module/PackageConfigRepository.java
@@ -1,0 +1,17 @@
+package com.dpis.module;
+
+final class PackageConfigRepository {
+    private final DpiConfigStore store;
+
+    PackageConfigRepository(DpiConfigStore store) {
+        this.store = store;
+    }
+
+    boolean hasRealPackageConfig(String packageName) {
+        return store != null && store.hasRealPackageConfig(packageName);
+    }
+
+    boolean writePackageTemplateConfigValue(String packageName, TemplateConfigValue value) {
+        return store != null && store.writePackageTemplateConfigValue(packageName, value);
+    }
+}

--- a/app/src/main/java/com/dpis/module/PackageConfigValue.java
+++ b/app/src/main/java/com/dpis/module/PackageConfigValue.java
@@ -1,0 +1,127 @@
+package com.dpis.module;
+
+import java.util.Objects;
+
+final class PackageConfigValue {
+    static final PackageConfigValue EMPTY = new PackageConfigValue(
+            ViewportTargetSpec.off(),
+            ViewportTargetType.OFF,
+            ViewportApplyMode.OFF,
+            null,
+            FontApplyMode.OFF,
+            null,
+            null,
+            null,
+            null);
+
+    final ViewportTargetSpec viewportTargetSpec;
+    final String viewportTargetType;
+    final String viewportApplyMode;
+    final Integer fontScalePercent;
+    final String fontApplyMode;
+    final String typefaceId;
+    final String fontHookDomainsRaw;
+    final Boolean dpisEnabled;
+    final Integer wechatDpi;
+
+    PackageConfigValue(
+            ViewportTargetSpec viewportTargetSpec,
+            String viewportTargetType,
+            String viewportApplyMode,
+            Integer fontScalePercent,
+            String fontApplyMode,
+            String typefaceId,
+            String fontHookDomainsRaw,
+            Boolean dpisEnabled,
+            Integer wechatDpi) {
+        this.viewportTargetSpec = viewportTargetSpec != null
+                ? viewportTargetSpec
+                : ViewportTargetSpec.off();
+        this.viewportTargetType = this.viewportTargetSpec.isEnabled()
+                ? this.viewportTargetSpec.type()
+                : ViewportTargetType.normalize(viewportTargetType);
+        this.viewportApplyMode = ViewportApplyMode.normalize(viewportApplyMode);
+        this.fontScalePercent = normalizeFontScalePercent(fontScalePercent);
+        this.fontApplyMode = FontApplyMode.normalize(fontApplyMode);
+        this.typefaceId = normalizeNullableString(typefaceId);
+        this.fontHookDomainsRaw = normalizeNullableString(fontHookDomainsRaw);
+        this.dpisEnabled = normalizeDpisEnabled(dpisEnabled);
+        this.wechatDpi = WechatDpiConfig.normalize(wechatDpi);
+    }
+
+    boolean hasAnyValue() {
+        return viewportTargetSpec.isEnabled()
+                || !ViewportTargetType.OFF.equals(viewportTargetType)
+                || isStoredViewportApplyMode(viewportApplyMode)
+                || fontScalePercent != null
+                || isStoredFontApplyMode(fontApplyMode)
+                || typefaceId != null
+                || fontHookDomainsRaw != null
+                || dpisEnabled != null
+                || wechatDpi != null;
+    }
+
+    private static String normalizeNullableString(String value) {
+        if (value == null) {
+            return null;
+        }
+        String trimmed = value.trim();
+        return trimmed.isEmpty() ? null : trimmed;
+    }
+
+    private static Integer normalizeFontScalePercent(Integer percent) {
+        if (percent == null || percent < 50 || percent > 300) {
+            return null;
+        }
+        return percent;
+    }
+
+    private static Boolean normalizeDpisEnabled(Boolean enabled) {
+        if (enabled == null || enabled) {
+            return null;
+        }
+        return Boolean.FALSE;
+    }
+
+    private static boolean isStoredViewportApplyMode(String mode) {
+        return ViewportApplyMode.SYSTEM.equals(mode)
+                || ViewportApplyMode.COMPAT.equals(mode);
+    }
+
+    private static boolean isStoredFontApplyMode(String mode) {
+        return FontApplyMode.FIELD_REWRITE.equals(mode);
+    }
+
+    @Override
+    public boolean equals(Object object) {
+        if (this == object) {
+            return true;
+        }
+        if (!(object instanceof PackageConfigValue other)) {
+            return false;
+        }
+        return viewportTargetSpec.equals(other.viewportTargetSpec)
+                && viewportTargetType.equals(other.viewportTargetType)
+                && viewportApplyMode.equals(other.viewportApplyMode)
+                && Objects.equals(fontScalePercent, other.fontScalePercent)
+                && fontApplyMode.equals(other.fontApplyMode)
+                && Objects.equals(typefaceId, other.typefaceId)
+                && Objects.equals(fontHookDomainsRaw, other.fontHookDomainsRaw)
+                && Objects.equals(dpisEnabled, other.dpisEnabled)
+                && Objects.equals(wechatDpi, other.wechatDpi);
+    }
+
+    @Override
+    public int hashCode() {
+        return Objects.hash(
+                viewportTargetSpec,
+                viewportTargetType,
+                viewportApplyMode,
+                fontScalePercent,
+                fontApplyMode,
+                typefaceId,
+                fontHookDomainsRaw,
+                dpisEnabled,
+                wechatDpi);
+    }
+}

--- a/app/src/main/java/com/dpis/module/QuickTemplateApplyCoordinator.java
+++ b/app/src/main/java/com/dpis/module/QuickTemplateApplyCoordinator.java
@@ -157,20 +157,20 @@ final class QuickTemplateApplyCoordinator {
     }
 
     private static final class StoreConfigWriter implements ConfigWriter {
-        private final DpiConfigStore store;
+        private final PackageConfigRepository packageConfigRepository;
 
         StoreConfigWriter(DpiConfigStore store) {
-            this.store = store;
+            this.packageConfigRepository = new PackageConfigRepository(store);
         }
 
         @Override
         public boolean hasRealPackageConfig(String packageName) {
-            return store != null && store.hasRealPackageConfig(packageName);
+            return packageConfigRepository.hasRealPackageConfig(packageName);
         }
 
         @Override
         public boolean writePackageTemplateConfigValue(String packageName, TemplateConfigValue value) {
-            return store != null && store.writePackageTemplateConfigValue(packageName, value);
+            return packageConfigRepository.writePackageTemplateConfigValue(packageName, value);
         }
     }
 

--- a/app/src/main/java/com/dpis/module/QuickTemplateTargetsBinder.java
+++ b/app/src/main/java/com/dpis/module/QuickTemplateTargetsBinder.java
@@ -56,7 +56,7 @@ final class QuickTemplateTargetsBinder {
     private final Host host;
     private final QuickTemplateStore quickTemplateStore;
     private final SharedPreferences filterPreferences;
-    private final DpiConfigStore configStore;
+    private final PackageConfigRepository packageConfigRepository;
     private final ExecutorService appLoadExecutor = Executors.newSingleThreadExecutor();
     private final ArrayList<TargetAppItem> allTargetItems = new ArrayList<>();
     private final LinkedHashSet<String> selectedPackages = new LinkedHashSet<>();
@@ -82,7 +82,8 @@ final class QuickTemplateTargetsBinder {
         this.quickTemplateStore = new QuickTemplateStore(preferences);
         this.filterPreferences = activity.getSharedPreferences(
                 FILTER_PREFS_NAME, Activity.MODE_PRIVATE);
-        this.configStore = DpisApplication.getActiveHookConfigStore(activity);
+        this.packageConfigRepository = new PackageConfigRepository(
+                DpisApplication.getActiveHookConfigStore(activity));
         this.filterShowSystemApps = filterPreferences.getBoolean(
                 KEY_FILTER_SHOW_SYSTEM_APPS, false);
         this.filterHideConfiguredApps = filterPreferences.getBoolean(
@@ -187,7 +188,7 @@ final class QuickTemplateTargetsBinder {
             loaded.add(new TargetAppItem(
                     item.label,
                     item.packageName,
-                    configStore.hasRealPackageConfig(item.packageName),
+                    packageConfigRepository.hasRealPackageConfig(item.packageName),
                     item.systemApp,
                     item.icon));
         }

--- a/app/src/main/java/com/dpis/module/SystemServerSettingsPageController.java
+++ b/app/src/main/java/com/dpis/module/SystemServerSettingsPageController.java
@@ -799,10 +799,9 @@ final class SystemServerSettingsPageController implements DpisApplication.Servic
                 success = false;
             }
             boolean finalSuccess = success;
-            int entryCount = entries.size();
             runOnUiThread(() -> {
                 if (finalSuccess) {
-                    showToast(R.string.config_backup_export_success, entryCount);
+                    showToast(R.string.config_backup_export_success);
                     return;
                 }
                 showToast(R.string.config_backup_export_failed);
@@ -829,9 +828,8 @@ final class SystemServerSettingsPageController implements DpisApplication.Servic
                 runOnUiThread(() -> showToast(R.string.config_backup_import_failed));
                 return;
             }
-            int entryCount = entries.size();
             runOnUiThread(() -> {
-                showToast(R.string.config_backup_import_success, entryCount);
+                showToast(R.string.config_backup_import_success);
                 relaunchDpisTask();
             });
         }, "dpis-config-backup-import").start();

--- a/app/src/main/res/values-ja-rJP/strings.xml
+++ b/app/src/main/res/values-ja-rJP/strings.xml
@@ -396,9 +396,9 @@
     <string name="config_backup_import_confirm_title">バックアップをインポート</string>
     <string name="config_backup_import_confirm_message">インポートすると現在の設定が上書きされます。続行しますか?</string>
     <string name="config_backup_confirm_import_action">インポート</string>
-    <string name="config_backup_export_success">%1$d 件の設定項目をエクスポートしました</string>
+    <string name="config_backup_export_success">バックアップをエクスポートしました</string>
     <string name="config_backup_export_failed">バックアップのエクスポートに失敗しました。再試行してください。</string>
-    <string name="config_backup_import_success">%1$d 件の設定項目をインポートしました</string>
+    <string name="config_backup_import_success">バックアップをインポートしました</string>
     <string name="config_backup_import_failed">バックアップのインポートに失敗しました。再試行してください。</string>
     <string name="config_backup_import_invalid">バックアップファイルが無効、またはサポートされていません</string>
     <string name="config_backup_picker_failed">ファイルピッカーを開けません</string>

--- a/app/src/main/res/values-ru-rRU/strings.xml
+++ b/app/src/main/res/values-ru-rRU/strings.xml
@@ -396,9 +396,9 @@
     <string name="config_backup_import_confirm_title">Импорт резервной копии</string>
     <string name="config_backup_import_confirm_message">Импорт приведет к перезаписи текущей конфигурации. Продолжить?</string>
     <string name="config_backup_confirm_import_action">Импорт</string>
-    <string name="config_backup_export_success">Экспортировано %1$d записей конфигурации</string>
+    <string name="config_backup_export_success">Резервная копия экспортирована</string>
     <string name="config_backup_export_failed">Не удалось экспортировать резервную копию. Попробуйте ещё раз.</string>
-    <string name="config_backup_import_success">Импортировано %1$d записей конфигурации</string>
+    <string name="config_backup_import_success">Резервная копия импортирована</string>
     <string name="config_backup_import_failed">Не удалось импортировать резервную копию. Попробуйте ещё раз.</string>
     <string name="config_backup_import_invalid">Файл резервной копии недействителен или не поддерживается</string>
     <string name="config_backup_picker_failed">Не удается открыть окно выбора файлов</string>

--- a/app/src/main/res/values-zh-rCN/strings.xml
+++ b/app/src/main/res/values-zh-rCN/strings.xml
@@ -396,9 +396,9 @@
     <string name="config_backup_import_confirm_title">导入备份</string>
     <string name="config_backup_import_confirm_message">导入将覆盖当前配置，是否继续？</string>
     <string name="config_backup_confirm_import_action">继续导入</string>
-    <string name="config_backup_export_success">已导出 %1$d 项配置</string>
+    <string name="config_backup_export_success">已导出备份</string>
     <string name="config_backup_export_failed">导出备份失败，请重试</string>
-    <string name="config_backup_import_success">已导入 %1$d 项配置</string>
+    <string name="config_backup_import_success">已导入备份</string>
     <string name="config_backup_import_failed">导入备份失败，请重试</string>
     <string name="config_backup_import_invalid">备份文件无效或版本不支持</string>
     <string name="config_backup_picker_failed">无法打开文件选择器</string>

--- a/app/src/main/res/values/strings.xml
+++ b/app/src/main/res/values/strings.xml
@@ -415,9 +415,9 @@
     <string name="config_backup_import_confirm_title">Import backup</string>
     <string name="config_backup_import_confirm_message">Import overwrites current config. Continue?</string>
     <string name="config_backup_confirm_import_action">Import</string>
-    <string name="config_backup_export_success">Exported %1$d config entries</string>
+    <string name="config_backup_export_success">Backup exported</string>
     <string name="config_backup_export_failed">Failed to export backup. Try again.</string>
-    <string name="config_backup_import_success">Imported %1$d config entries</string>
+    <string name="config_backup_import_success">Backup imported</string>
     <string name="config_backup_import_failed">Failed to import backup. Try again.</string>
     <string name="config_backup_import_invalid">Backup file is invalid or unsupported</string>
     <string name="config_backup_picker_failed">Unable to open file picker</string>

--- a/app/src/modern/java/com/dpis/module/ModernAppSpecificRouteInstaller.java
+++ b/app/src/modern/java/com/dpis/module/ModernAppSpecificRouteInstaller.java
@@ -1,5 +1,6 @@
 package com.dpis.module;
 
+import android.annotation.SuppressLint;
 import android.app.Application;
 import android.content.Context;
 
@@ -26,6 +27,7 @@ final class ModernAppSpecificRouteInstaller {
         installWechatApplicationAttachHook(xposed);
     }
 
+    @SuppressLint("NewApi")
     static boolean handlePackageLoaded(XposedModule xposed,
             XposedModule.PackageLoadedParam param,
             String processName) {

--- a/app/src/test/java/com/dpis/module/AppConfigPrefillPreviewTest.java
+++ b/app/src/test/java/com/dpis/module/AppConfigPrefillPreviewTest.java
@@ -2,6 +2,8 @@ package com.dpis.module;
 
 import org.junit.Test;
 
+import java.io.IOException;
+
 import static org.junit.Assert.assertEquals;
 import static org.junit.Assert.assertFalse;
 import static org.junit.Assert.assertNull;
@@ -9,6 +11,15 @@ import static org.junit.Assert.assertSame;
 import static org.junit.Assert.assertTrue;
 
 public class AppConfigPrefillPreviewTest {
+    @Test
+    public void prefillEligibilityReadsPackageConfigThroughRepository() throws IOException {
+        String source = SourceSmokeTestPaths.read(
+                "src/main/java/com/dpis/module/AppConfigPrefillPreview.java");
+
+        assertTrue(source.contains("new PackageConfigRepository(store)"));
+        assertTrue(source.contains("packageConfigRepository.hasRealPackageConfig("));
+    }
+
     @Test
     public void configuredAppsIgnoreGlobalPrefill() {
         DpiConfigStore store = new DpiConfigStore(new FakePrefs());

--- a/app/src/test/java/com/dpis/module/ConfigBackupCodecSourceSmokeTest.java
+++ b/app/src/test/java/com/dpis/module/ConfigBackupCodecSourceSmokeTest.java
@@ -11,7 +11,12 @@ public class ConfigBackupCodecSourceSmokeTest {
     public void codecDefinesSchemaAndSupportedValueTypes() throws IOException {
         String source = read("src/main/java/com/dpis/module/ConfigBackupCodec.java");
 
-        assertTrue(source.contains("SCHEMA_VERSION = 1"));
+        assertTrue(source.contains("SCHEMA_VERSION = 2"));
+        assertTrue(source.contains("KEY_PACKAGE_CONFIGS"));
+        assertTrue(source.contains("decodeSchemaV1"));
+        assertTrue(source.contains("packageConfigs"));
+        assertTrue(source.contains("package_config."));
+        assertTrue(source.contains("packageConfigFieldKeyFromRemainder"));
         assertTrue(source.contains("TYPE_STRING_SET"));
         assertTrue(source.contains("TYPE_INT"));
         assertTrue(source.contains("TYPE_LONG"));
@@ -31,6 +36,8 @@ public class ConfigBackupCodecSourceSmokeTest {
         assertTrue(store.contains("\"font.\" + packageName + \".typeface_id\""));
         assertTrue(settings.contains("Map<String, Object> entries = localStore.snapshotBackup();"));
         assertTrue(settings.contains("String payload = ConfigBackupCodec.encode(entries);"));
+        assertTrue(codec.contains("putEncodedPackageConfigEntry"));
+        assertTrue(codec.contains("decodePackageConfigsInto"));
         assertTrue(codec.contains("encoded.put(KEY_TYPE, TYPE_STRING);"));
         assertTrue(codec.contains("case TYPE_STRING -> encoded.optString(KEY_VALUE, \"\")"));
         assertTrue(codec.contains("TYPE_STRING"));

--- a/app/src/test/java/com/dpis/module/ConfigBackupCodecSourceSmokeTest.java
+++ b/app/src/test/java/com/dpis/module/ConfigBackupCodecSourceSmokeTest.java
@@ -11,10 +11,16 @@ public class ConfigBackupCodecSourceSmokeTest {
     public void codecDefinesSchemaAndSupportedValueTypes() throws IOException {
         String source = read("src/main/java/com/dpis/module/ConfigBackupCodec.java");
 
-        assertTrue(source.contains("SCHEMA_VERSION = 2"));
+        assertTrue(source.contains("SCHEMA_VERSION = 3"));
         assertTrue(source.contains("KEY_PACKAGE_CONFIGS"));
+        assertTrue(source.contains("KEY_RESOLUTION_CONFIGS"));
+        assertTrue(source.contains("KEY_GLOBAL"));
+        assertTrue(source.contains("KEY_DEFAULT_PREFILL"));
+        assertTrue(source.contains("KEY_TEMPLATES"));
         assertTrue(source.contains("decodeSchemaV1"));
+        assertTrue(source.contains("decodeSchemaV2"));
         assertTrue(source.contains("packageConfigs"));
+        assertTrue(source.contains("defaultPrefill"));
         assertTrue(source.contains("package_config."));
         assertTrue(source.contains("packageConfigFieldKeyFromRemainder"));
         assertTrue(source.contains("KEY_TYPE"));
@@ -34,7 +40,12 @@ public class ConfigBackupCodecSourceSmokeTest {
         assertTrue(settings.contains("Map<String, Object> entries = localStore.snapshotBackup();"));
         assertTrue(settings.contains("String payload = ConfigBackupCodec.encode(entries);"));
         assertTrue(codec.contains("putPackageConfigEntry"));
+        assertTrue(codec.contains("putPackageOwnedConfigEntry"));
+        assertTrue(codec.contains("putDefaultPrefillEntry"));
+        assertTrue(codec.contains("putTemplateEntry"));
         assertTrue(codec.contains("decodePackageConfigsInto"));
+        assertTrue(codec.contains("decodePackageOwnedConfigsInto"));
+        assertTrue(codec.contains("decodeTemplatesInto"));
         assertTrue(settings.contains("ConfigBackupCodec.decode(payload)"));
         assertTrue(settings.contains("localStore.replaceBackup(entries)"));
         assertTrue(store.contains("BACKUP_EXCLUDED_PREFIXES"));

--- a/app/src/test/java/com/dpis/module/ConfigBackupCodecSourceSmokeTest.java
+++ b/app/src/test/java/com/dpis/module/ConfigBackupCodecSourceSmokeTest.java
@@ -17,11 +17,8 @@ public class ConfigBackupCodecSourceSmokeTest {
         assertTrue(source.contains("packageConfigs"));
         assertTrue(source.contains("package_config."));
         assertTrue(source.contains("packageConfigFieldKeyFromRemainder"));
-        assertTrue(source.contains("TYPE_STRING_SET"));
-        assertTrue(source.contains("TYPE_INT"));
-        assertTrue(source.contains("TYPE_LONG"));
-        assertTrue(source.contains("TYPE_FLOAT"));
-        assertTrue(source.contains("TYPE_BOOLEAN"));
+        assertTrue(source.contains("KEY_TYPE"));
+        assertTrue(source.contains("KEY_VALUE"));
         assertTrue(source.contains("switch (type)"));
         assertTrue(source.contains("Unsupported backup schema version"));
         assertTrue(source.contains("Unsupported backup value type"));
@@ -36,11 +33,8 @@ public class ConfigBackupCodecSourceSmokeTest {
         assertTrue(store.contains("\"font.\" + packageName + \".typeface_id\""));
         assertTrue(settings.contains("Map<String, Object> entries = localStore.snapshotBackup();"));
         assertTrue(settings.contains("String payload = ConfigBackupCodec.encode(entries);"));
-        assertTrue(codec.contains("putEncodedPackageConfigEntry"));
+        assertTrue(codec.contains("putPackageConfigEntry"));
         assertTrue(codec.contains("decodePackageConfigsInto"));
-        assertTrue(codec.contains("encoded.put(KEY_TYPE, TYPE_STRING);"));
-        assertTrue(codec.contains("case TYPE_STRING -> encoded.optString(KEY_VALUE, \"\")"));
-        assertTrue(codec.contains("TYPE_STRING"));
         assertTrue(settings.contains("ConfigBackupCodec.decode(payload)"));
         assertTrue(settings.contains("localStore.replaceBackup(entries)"));
         assertTrue(store.contains("BACKUP_EXCLUDED_PREFIXES"));

--- a/app/src/test/java/com/dpis/module/DpiConfigStoreTest.java
+++ b/app/src/test/java/com/dpis/module/DpiConfigStoreTest.java
@@ -1121,6 +1121,7 @@ public class DpiConfigStoreTest {
 
         Map<String, Object> snapshot = store.snapshotBackup();
 
+        assertFalse(snapshot.containsKey(DpiConfigStore.KEY_TARGET_PACKAGES));
         assertFalse(snapshot.containsKey("font.com.max.xiaoheihe.typeface_id"));
         assertEquals("font_abcd1234",
                 snapshot.get("package_config.com.max.xiaoheihe.font.typeface_id"));
@@ -1165,6 +1166,7 @@ public class DpiConfigStoreTest {
 
         assertEquals("missing_font_id", all.get("default_config.font.typeface_id"));
         assertEquals("Compact", all.get("template.template_a.name"));
+        assertFalse(backup.containsKey(DpiConfigStore.KEY_TARGET_PACKAGES));
         assertEquals("missing_font_id", backup.get("default_config.font.typeface_id"));
         assertEquals(411, backup.get("default_config.viewport.width_dp"));
         assertEquals(ViewportApplyMode.AUTO, backup.get("default_config.viewport.mode"));

--- a/app/src/test/java/com/dpis/module/DpiConfigStoreTest.java
+++ b/app/src/test/java/com/dpis/module/DpiConfigStoreTest.java
@@ -1110,6 +1110,8 @@ public class DpiConfigStoreTest {
                 .putStringSet(DpiConfigStore.KEY_TARGET_PACKAGES,
                         new LinkedHashSet<>(Set.of("com.max.xiaoheihe")))
                 .putString("font.com.max.xiaoheihe.typeface_id", "font_abcd1234")
+                .putString("package_config.com.max.xiaoheihe.font.typeface_id",
+                        "font_abcd1234")
                 .putString("font.library.entries", "[{\"id\":\"font_abcd1234\"}]")
                 .putBoolean("font.debug.overlay_enabled", true)
                 .putString("runtime.log.ring", "debug log")
@@ -1119,7 +1121,9 @@ public class DpiConfigStoreTest {
 
         Map<String, Object> snapshot = store.snapshotBackup();
 
-        assertEquals("font_abcd1234", snapshot.get("font.com.max.xiaoheihe.typeface_id"));
+        assertFalse(snapshot.containsKey("font.com.max.xiaoheihe.typeface_id"));
+        assertEquals("font_abcd1234",
+                snapshot.get("package_config.com.max.xiaoheihe.font.typeface_id"));
         assertFalse(snapshot.containsKey("font.library.entries"));
         assertFalse(snapshot.containsKey("font.debug.overlay_enabled"));
         assertFalse(snapshot.containsKey("runtime.log.ring"));
@@ -1261,6 +1265,62 @@ public class DpiConfigStoreTest {
         assertEquals("local_done", prefs.getString("font.library.migration_state", null));
         assertTrue(prefs.getBoolean("font.debug.overlay_enabled", false));
         assertEquals("local debug log", prefs.getString("runtime.log.ring", null));
+    }
+
+    @Test
+    public void replaceBackupMigratesLegacyPackageConfigAndDeletesLegacyKeys() {
+        FakePrefs prefs = new FakePrefs();
+        DpiConfigStore store = new DpiConfigStore(prefs);
+        LinkedHashMap<String, Object> values = new LinkedHashMap<>();
+        values.put(DpiConfigStore.KEY_TARGET_PACKAGES,
+                new LinkedHashSet<>(Set.of("com.tencent.mm")));
+        values.put("viewport.com.tencent.mm.target_type", ViewportTargetType.RELATIVE_SCALE);
+        values.put("viewport.com.tencent.mm.scale_permille", 1250);
+        values.put("font.com.tencent.mm.hook_domains", " resources_font,textview_sp ");
+        values.put("target.com.tencent.mm.dpis_enabled", false);
+        values.put("wechat.com.tencent.mm.dpi", 600);
+
+        assertTrue(store.replaceBackup(values));
+
+        assertEquals(ViewportTargetSpec.relativeScale(1250),
+                store.readPackageConfig("com.tencent.mm").viewportTargetSpec);
+        assertEquals("resources_font,textview_sp",
+                store.readPackageConfig("com.tencent.mm").fontHookDomainsRaw);
+        assertFalse(store.isTargetDpisEnabled("com.tencent.mm"));
+        assertEquals(Integer.valueOf(600), store.getWechatDpi("com.tencent.mm"));
+        assertEquals(ViewportTargetType.RELATIVE_SCALE,
+                prefs.getString("package_config.com.tencent.mm.viewport.target_type", null));
+        assertEquals("resources_font,textview_sp",
+                prefs.getString("package_config.com.tencent.mm.font.hook_domains", null));
+        assertFalse(prefs.contains("viewport.com.tencent.mm.target_type"));
+        assertFalse(prefs.contains("viewport.com.tencent.mm.scale_permille"));
+        assertFalse(prefs.contains("font.com.tencent.mm.hook_domains"));
+        assertFalse(prefs.contains("target.com.tencent.mm.dpis_enabled"));
+        assertFalse(prefs.contains("wechat.com.tencent.mm.dpi"));
+    }
+
+    @Test
+    public void replaceBackupKeepsAggregatedPackageConfigWhenLegacyBackupConflicts() {
+        FakePrefs prefs = new FakePrefs();
+        DpiConfigStore store = new DpiConfigStore(prefs);
+        LinkedHashMap<String, Object> values = new LinkedHashMap<>();
+        values.put("viewport.com.example.app.target_type", ViewportTargetType.ABSOLUTE_DP);
+        values.put("viewport.com.example.app.width_dp", 411);
+        values.put("package_config.com.example.app.viewport.target_type",
+                ViewportTargetType.RELATIVE_SCALE);
+        values.put("package_config.com.example.app.viewport.scale_permille", 900);
+
+        assertTrue(store.replaceBackup(values));
+
+        assertEquals(ViewportTargetSpec.relativeScale(900),
+                store.readPackageConfig("com.example.app").viewportTargetSpec);
+        assertFalse(prefs.contains("viewport.com.example.app.target_type"));
+        assertFalse(prefs.contains("viewport.com.example.app.width_dp"));
+        assertEquals(ViewportTargetType.RELATIVE_SCALE,
+                prefs.getString("package_config.com.example.app.viewport.target_type", null));
+        assertEquals(Integer.valueOf(900),
+                Integer.valueOf(prefs.getInt(
+                        "package_config.com.example.app.viewport.scale_permille", 0)));
     }
 
     @Test
@@ -1555,6 +1615,105 @@ public class DpiConfigStoreTest {
                 "resources_font,textview_sp",
                 false,
                 600), value);
+    }
+
+    @Test
+    public void migrateLegacyPackageConfigToAggregatedCopiesLegacyOnlyAndDeletesLegacyKeys() {
+        FakePrefs prefs = new FakePrefs();
+        prefs.edit()
+                .putStringSet(DpiConfigStore.KEY_TARGET_PACKAGES,
+                        new LinkedHashSet<>(Set.of("com.tencent.mm")))
+                .putString("viewport.com.tencent.mm.target_type",
+                        ViewportTargetType.RELATIVE_SCALE)
+                .putInt("viewport.com.tencent.mm.scale_permille", 1250)
+                .putString("viewport.com.tencent.mm.mode",
+                        ViewportApplyMode.SYSTEM)
+                .putInt("font.com.tencent.mm.scale_percent", 140)
+                .putString("font.com.tencent.mm.mode",
+                        FontApplyMode.FIELD_REWRITE)
+                .putString("font.com.tencent.mm.typeface_id", "test_font")
+                .putString("font.com.tencent.mm.hook_domains", "resources_font")
+                .putBoolean("target.com.tencent.mm.dpis_enabled", false)
+                .putInt("wechat.com.tencent.mm.dpi", 600)
+                .commit();
+        DpiConfigStore store = new DpiConfigStore(prefs);
+
+        assertTrue(store.migrateLegacyPackageConfigToAggregated());
+
+        assertEquals(new PackageConfigValue(
+                ViewportTargetSpec.relativeScale(1250),
+                ViewportTargetType.RELATIVE_SCALE,
+                ViewportApplyMode.SYSTEM,
+                140,
+                FontApplyMode.FIELD_REWRITE,
+                "test_font",
+                "resources_font",
+                false,
+                600), store.readPackageConfig("com.tencent.mm"));
+        assertEquals(ViewportTargetType.RELATIVE_SCALE,
+                prefs.getString("package_config.com.tencent.mm.viewport.target_type", null));
+        assertEquals(Integer.valueOf(1250),
+                Integer.valueOf(prefs.getInt(
+                        "package_config.com.tencent.mm.viewport.scale_permille", 0)));
+        assertEquals(Integer.valueOf(140),
+                Integer.valueOf(prefs.getInt(
+                        "package_config.com.tencent.mm.font.scale_percent", 0)));
+        assertFalse(prefs.getBoolean(
+                "package_config.com.tencent.mm.target.dpis_enabled", true));
+        assertEquals(Integer.valueOf(600),
+                Integer.valueOf(prefs.getInt(
+                        "package_config.com.tencent.mm.app.wechat_dpi", 0)));
+        assertFalse(prefs.contains("viewport.com.tencent.mm.target_type"));
+        assertFalse(prefs.contains("viewport.com.tencent.mm.scale_permille"));
+        assertFalse(prefs.contains("font.com.tencent.mm.scale_percent"));
+        assertFalse(prefs.contains("font.com.tencent.mm.typeface_id"));
+        assertFalse(prefs.contains("target.com.tencent.mm.dpis_enabled"));
+        assertFalse(prefs.contains("wechat.com.tencent.mm.dpi"));
+    }
+
+    @Test
+    public void migrateLegacyPackageConfigToAggregatedKeepsAggregatedValueOnConflict() {
+        FakePrefs prefs = new FakePrefs();
+        prefs.edit()
+                .putString("viewport.com.example.app.target_type",
+                        ViewportTargetType.ABSOLUTE_DP)
+                .putInt("viewport.com.example.app.width_dp", 411)
+                .putInt("font.com.example.app.scale_percent", 130)
+                .putString("package_config.com.example.app.viewport.target_type",
+                        ViewportTargetType.RELATIVE_SCALE)
+                .putInt("package_config.com.example.app.viewport.scale_permille", 900)
+                .putInt("package_config.com.example.app.font.scale_percent", 150)
+                .commit();
+        DpiConfigStore store = new DpiConfigStore(prefs);
+
+        assertTrue(store.migrateLegacyPackageConfigToAggregated());
+
+        assertEquals(ViewportTargetSpec.relativeScale(900),
+                store.readPackageConfig("com.example.app").viewportTargetSpec);
+        assertEquals(Integer.valueOf(150),
+                store.readPackageConfig("com.example.app").fontScalePercent);
+        assertFalse(prefs.contains("viewport.com.example.app.target_type"));
+        assertFalse(prefs.contains("viewport.com.example.app.width_dp"));
+        assertFalse(prefs.contains("font.com.example.app.scale_percent"));
+    }
+
+    @Test
+    public void migrateLegacyPackageConfigToAggregatedIgnoresInvalidWechatAndTargetPackagesOnly() {
+        FakePrefs prefs = new FakePrefs();
+        prefs.edit()
+                .putStringSet(DpiConfigStore.KEY_TARGET_PACKAGES,
+                        new LinkedHashSet<>(Set.of("com.example.target_only")))
+                .putInt("wechat.com.example.app.dpi", 600)
+                .commit();
+        DpiConfigStore store = new DpiConfigStore(prefs);
+
+        assertTrue(store.migrateLegacyPackageConfigToAggregated());
+
+        assertFalse(prefs.contains("package_config.com.example.app.app.wechat_dpi"));
+        assertFalse(store.hasUserVisiblePackageConfig("com.example.app"));
+        assertFalse(store.hasUserVisiblePackageConfig("com.example.target_only"));
+        assertEquals(PackageConfigValue.EMPTY, store.readPackageConfig("com.example.target_only"));
+        assertFalse(prefs.contains("wechat.com.example.app.dpi"));
     }
 
     @Test

--- a/app/src/test/java/com/dpis/module/DpiConfigStoreTest.java
+++ b/app/src/test/java/com/dpis/module/DpiConfigStoreTest.java
@@ -207,6 +207,141 @@ public class DpiConfigStoreTest {
     }
 
     @Test
+    public void viewportGettersReadAggregatedViewportKeys() {
+        FakePrefs prefs = new FakePrefs();
+        prefs.edit()
+                .putString("package_config.com.example.app.viewport.target_type",
+                        ViewportTargetType.RELATIVE_SCALE)
+                .putInt("package_config.com.example.app.viewport.scale_permille", 1250)
+                .putString("package_config.com.example.app.viewport.mode",
+                        ViewportApplyMode.SYSTEM)
+                .commit();
+        DpiConfigStore store = new DpiConfigStore(prefs);
+
+        assertEquals(ViewportTargetType.RELATIVE_SCALE,
+                store.getTargetViewportType("com.example.app"));
+        assertEquals(Integer.valueOf(1250),
+                store.getTargetViewportScalePermille("com.example.app"));
+        assertEquals(ViewportTargetSpec.relativeScale(1250),
+                store.getTargetViewportSpec("com.example.app"));
+        assertEquals(ViewportApplyMode.SYSTEM,
+                store.getTargetViewportApplyMode("com.example.app"));
+    }
+
+    @Test
+    public void viewportSetterWritesLegacyAndAggregatedKeys() {
+        FakePrefs prefs = new FakePrefs();
+        DpiConfigStore store = new DpiConfigStore(prefs);
+
+        assertTrue(store.setTargetViewportSpec(
+                "com.example.app", ViewportTargetSpec.relativeScale(1250)));
+
+        assertEquals(ViewportTargetType.RELATIVE_SCALE,
+                prefs.getString("viewport.com.example.app.target_type", null));
+        assertEquals(ViewportTargetType.RELATIVE_SCALE,
+                prefs.getString("package_config.com.example.app.viewport.target_type", null));
+        assertEquals(Integer.valueOf(1250),
+                Integer.valueOf(prefs.getInt(
+                        "viewport.com.example.app.scale_permille", 0)));
+        assertEquals(Integer.valueOf(1250),
+                Integer.valueOf(prefs.getInt(
+                        "package_config.com.example.app.viewport.scale_permille", 0)));
+        assertTrue(store.getConfiguredPackages().contains("com.example.app"));
+        assertTrue(store.hasUserVisiblePackageConfig("com.example.app"));
+    }
+
+    @Test
+    public void viewportSpecSetterPreservesExistingApplyMode() {
+        FakePrefs prefs = new FakePrefs();
+        DpiConfigStore store = new DpiConfigStore(prefs);
+        assertTrue(store.setTargetViewportApplyMode("com.example.app", ViewportApplyMode.SYSTEM));
+
+        assertTrue(store.setTargetViewportSpec(
+                "com.example.app", ViewportTargetSpec.relativeScale(1250)));
+
+        assertEquals(ViewportApplyMode.SYSTEM,
+                prefs.getString("viewport.com.example.app.mode", null));
+        assertEquals(ViewportApplyMode.SYSTEM,
+                prefs.getString("package_config.com.example.app.viewport.mode", null));
+        assertEquals(ViewportApplyMode.SYSTEM,
+                store.getTargetViewportApplyMode("com.example.app"));
+    }
+
+    @Test
+    public void viewportWidthSetterPreservesExistingApplyMode() {
+        FakePrefs prefs = new FakePrefs();
+        DpiConfigStore store = new DpiConfigStore(prefs);
+        assertTrue(store.setTargetViewportApplyMode("com.example.app", ViewportApplyMode.COMPAT));
+
+        assertTrue(store.setTargetViewportWidthDp("com.example.app", 411));
+
+        assertEquals(ViewportApplyMode.COMPAT,
+                prefs.getString("viewport.com.example.app.mode", null));
+        assertEquals(ViewportApplyMode.COMPAT,
+                prefs.getString("package_config.com.example.app.viewport.mode", null));
+        assertEquals(ViewportApplyMode.COMPAT,
+                store.getTargetViewportApplyMode("com.example.app"));
+    }
+
+    @Test
+    public void viewportClearRemovesLegacyAndAggregatedKeys() {
+        FakePrefs prefs = new FakePrefs();
+        DpiConfigStore store = new DpiConfigStore(prefs);
+        assertTrue(store.setTargetViewportSpec(
+                "com.example.app", ViewportTargetSpec.relativeScale(1250)));
+        assertTrue(store.setTargetViewportApplyMode("com.example.app", ViewportApplyMode.SYSTEM));
+
+        assertTrue(store.clearTargetViewportWidthDp("com.example.app"));
+
+        assertNull(store.getTargetViewportScalePermille("com.example.app"));
+        assertEquals(ViewportTargetType.OFF, store.getTargetViewportType("com.example.app"));
+        assertEquals(ViewportApplyMode.OFF, store.getTargetViewportApplyMode("com.example.app"));
+        assertFalse(prefs.contains("viewport.com.example.app.target_type"));
+        assertFalse(prefs.contains("viewport.com.example.app.scale_permille"));
+        assertFalse(prefs.contains("viewport.com.example.app.mode"));
+        assertFalse(prefs.contains("package_config.com.example.app.viewport.target_type"));
+        assertFalse(prefs.contains("package_config.com.example.app.viewport.scale_permille"));
+        assertFalse(prefs.contains("package_config.com.example.app.viewport.mode"));
+        assertFalse(store.getConfiguredPackages().contains("com.example.app"));
+    }
+
+    @Test
+    public void legacyOnlyViewportKeysRemainReadable() {
+        FakePrefs prefs = new FakePrefs();
+        prefs.edit()
+                .putString("viewport.com.example.app.target_type",
+                        ViewportTargetType.ABSOLUTE_DP)
+                .putInt("viewport.com.example.app.width_dp", 411)
+                .putString("viewport.com.example.app.mode", ViewportApplyMode.COMPAT)
+                .commit();
+        DpiConfigStore store = new DpiConfigStore(prefs);
+
+        assertEquals(ViewportTargetType.ABSOLUTE_DP,
+                store.getTargetViewportType("com.example.app"));
+        assertEquals(Integer.valueOf(411), store.getTargetViewportWidthDp("com.example.app"));
+        assertEquals(ViewportTargetSpec.absoluteDp(411),
+                store.getTargetViewportSpec("com.example.app"));
+        assertEquals(ViewportApplyMode.COMPAT,
+                store.getTargetViewportApplyMode("com.example.app"));
+    }
+
+    @Test
+    public void configuredPackagesIncludeMixedLegacyAndAggregatedViewportState() {
+        FakePrefs prefs = new FakePrefs();
+        prefs.edit()
+                .putInt("viewport.com.example.legacy.width_dp", 411)
+                .putString("package_config.com.example.aggregated.viewport.mode",
+                        ViewportApplyMode.SYSTEM)
+                .commit();
+        DpiConfigStore store = new DpiConfigStore(prefs);
+
+        assertTrue(store.getConfiguredPackages().contains("com.example.legacy"));
+        assertTrue(store.getConfiguredPackages().contains("com.example.aggregated"));
+        assertTrue(store.hasUserVisiblePackageConfig("com.example.legacy"));
+        assertTrue(store.hasUserVisiblePackageConfig("com.example.aggregated"));
+    }
+
+    @Test
     public void updatesFontScaleForConfiguredPackage() {
         FakePrefs prefs = new FakePrefs();
         DpiConfigStore store = new DpiConfigStore(prefs);
@@ -214,7 +349,192 @@ public class DpiConfigStoreTest {
         assertTrue(store.setTargetFontScalePercent("bin.mt.plus.canary", 115));
 
         assertEquals(Integer.valueOf(115), store.getTargetFontScalePercent("bin.mt.plus.canary"));
+        assertEquals(Integer.valueOf(115),
+                Integer.valueOf(prefs.getInt("font.bin.mt.plus.canary.scale_percent", 0)));
+        assertEquals(Integer.valueOf(115),
+                Integer.valueOf(prefs.getInt(
+                        "package_config.bin.mt.plus.canary.font.scale_percent", 0)));
         assertTrue(store.getConfiguredPackages().contains("bin.mt.plus.canary"));
+    }
+
+    @Test
+    public void fontGettersReadAggregatedFontKeys() {
+        FakePrefs prefs = new FakePrefs();
+        prefs.edit()
+                .putInt("package_config.com.example.app.font.scale_percent", 135)
+                .putString("package_config.com.example.app.font.mode",
+                        FontApplyMode.FIELD_REWRITE)
+                .putString("package_config.com.example.app.font.typeface_id",
+                        "font_abcd1234")
+                .commit();
+        DpiConfigStore store = new DpiConfigStore(prefs);
+
+        assertEquals(Integer.valueOf(135), store.getTargetFontScalePercent("com.example.app"));
+        assertEquals(FontApplyMode.FIELD_REWRITE,
+                store.getTargetFontApplyMode("com.example.app"));
+        assertEquals("font_abcd1234", store.getTargetTypefaceId("com.example.app"));
+    }
+
+    @Test
+    public void fontSetterWritesLegacyAndAggregatedKeys() {
+        FakePrefs prefs = new FakePrefs();
+        DpiConfigStore store = new DpiConfigStore(prefs);
+
+        assertTrue(store.setTargetFontScalePercent("com.example.app", 135));
+        assertTrue(store.setTargetFontApplyMode("com.example.app", FontApplyMode.FIELD_REWRITE));
+        assertTrue(store.setTargetTypefaceId("com.example.app", "font_abcd1234"));
+
+        assertEquals(Integer.valueOf(135),
+                Integer.valueOf(prefs.getInt("font.com.example.app.scale_percent", 0)));
+        assertEquals(Integer.valueOf(135),
+                Integer.valueOf(prefs.getInt(
+                        "package_config.com.example.app.font.scale_percent", 0)));
+        assertEquals(FontApplyMode.FIELD_REWRITE,
+                prefs.getString("font.com.example.app.mode", null));
+        assertEquals(FontApplyMode.FIELD_REWRITE,
+                prefs.getString("package_config.com.example.app.font.mode", null));
+        assertEquals("font_abcd1234",
+                prefs.getString("font.com.example.app.typeface_id", null));
+        assertEquals("font_abcd1234",
+                prefs.getString("package_config.com.example.app.font.typeface_id", null));
+    }
+
+    @Test
+    public void fontClearRemovesLegacyAndAggregatedKeys() {
+        FakePrefs prefs = new FakePrefs();
+        DpiConfigStore store = new DpiConfigStore(prefs);
+        assertTrue(store.setTargetFontScalePercent("com.example.app", 135));
+        assertTrue(store.setTargetTypefaceId("com.example.app", "font_abcd1234"));
+
+        assertTrue(store.clearTargetFontScalePercent("com.example.app"));
+        assertTrue(store.clearTargetTypefaceId("com.example.app"));
+        assertTrue(store.setTargetFontApplyMode("com.example.app", FontApplyMode.OFF));
+
+        assertNull(store.getTargetFontScalePercent("com.example.app"));
+        assertNull(store.getTargetTypefaceId("com.example.app"));
+        assertEquals(FontApplyMode.OFF, store.getTargetFontApplyMode("com.example.app"));
+        assertFalse(prefs.contains("font.com.example.app.scale_percent"));
+        assertFalse(prefs.contains("package_config.com.example.app.font.scale_percent"));
+        assertFalse(prefs.contains("font.com.example.app.typeface_id"));
+        assertFalse(prefs.contains("package_config.com.example.app.font.typeface_id"));
+        assertFalse(prefs.contains("font.com.example.app.mode"));
+        assertFalse(prefs.contains("package_config.com.example.app.font.mode"));
+        assertFalse(store.getConfiguredPackages().contains("com.example.app"));
+    }
+
+    @Test
+    public void legacyOnlyFontKeysRemainReadable() {
+        FakePrefs prefs = new FakePrefs();
+        prefs.edit()
+                .putInt("font.com.example.app.scale_percent", 135)
+                .putString("font.com.example.app.mode", FontApplyMode.FIELD_REWRITE)
+                .putString("font.com.example.app.typeface_id", "font_abcd1234")
+                .commit();
+        DpiConfigStore store = new DpiConfigStore(prefs);
+
+        assertEquals(Integer.valueOf(135), store.getTargetFontScalePercent("com.example.app"));
+        assertEquals(FontApplyMode.FIELD_REWRITE,
+                store.getTargetFontApplyMode("com.example.app"));
+        assertEquals("font_abcd1234", store.getTargetTypefaceId("com.example.app"));
+    }
+
+    @Test
+    public void configuredPackagesIncludeMixedLegacyAndAggregatedFontState() {
+        FakePrefs prefs = new FakePrefs();
+        prefs.edit()
+                .putString("font.com.example.legacy.mode", FontApplyMode.FIELD_REWRITE)
+                .putString("package_config.com.example.aggregated.font.mode",
+                        FontApplyMode.FIELD_REWRITE)
+                .commit();
+        DpiConfigStore store = new DpiConfigStore(prefs);
+
+        assertTrue(store.getConfiguredPackages().contains("com.example.legacy"));
+        assertTrue(store.getConfiguredPackages().contains("com.example.aggregated"));
+        assertTrue(store.hasUserVisiblePackageConfig("com.example.legacy"));
+        assertTrue(store.hasUserVisiblePackageConfig("com.example.aggregated"));
+    }
+
+    @Test
+    public void aggregatedFontScaleDefaultsModeToSystemEmulationWhenModeMissing() {
+        FakePrefs prefs = new FakePrefs();
+        prefs.edit()
+                .putInt("package_config.com.example.app.font.scale_percent", 135)
+                .commit();
+        DpiConfigStore store = new DpiConfigStore(prefs);
+
+        assertEquals(FontApplyMode.SYSTEM_EMULATION,
+                store.getTargetFontApplyMode("com.example.app"));
+    }
+
+    @Test
+    public void hookDomainGetterReadsAggregatedKey() {
+        FakePrefs prefs = new FakePrefs();
+        prefs.edit()
+                .putString("package_config.com.example.app.font.hook_domains",
+                        "resources_font,textview_sp")
+                .commit();
+        DpiConfigStore store = new DpiConfigStore(prefs);
+
+        assertEquals("resources_font,textview_sp",
+                store.getPackageFontHookDomainsRaw("com.example.app"));
+    }
+
+    @Test
+    public void hookDomainSetterWritesLegacyAndAggregatedKeys() {
+        FakePrefs prefs = new FakePrefs();
+        DpiConfigStore store = new DpiConfigStore(prefs);
+
+        assertTrue(store.setPackageFontHookDomainsRaw(
+                "com.example.app", "resources_font,textview_sp"));
+
+        assertEquals("resources_font,textview_sp",
+                prefs.getString("font.com.example.app.hook_domains", null));
+        assertEquals("resources_font,textview_sp",
+                prefs.getString(
+                        "package_config.com.example.app.font.hook_domains", null));
+        assertTrue(store.getConfiguredPackages().contains("com.example.app"));
+        assertTrue(store.hasUserVisiblePackageConfig("com.example.app"));
+    }
+
+    @Test
+    public void hookDomainClearRemovesLegacyAndAggregatedKeys() {
+        FakePrefs prefs = new FakePrefs();
+        DpiConfigStore store = new DpiConfigStore(prefs);
+        assertTrue(store.setPackageFontHookDomainsRaw("com.example.app", "resources_font"));
+
+        assertTrue(store.clearPackageFontHookDomainsRaw("com.example.app"));
+
+        assertNull(store.getPackageFontHookDomainsRaw("com.example.app"));
+        assertFalse(prefs.contains("font.com.example.app.hook_domains"));
+        assertFalse(prefs.contains("package_config.com.example.app.font.hook_domains"));
+        assertFalse(store.getConfiguredPackages().contains("com.example.app"));
+    }
+
+    @Test
+    public void legacyOnlyHookDomainKeyRemainsReadable() {
+        FakePrefs prefs = new FakePrefs();
+        prefs.edit()
+                .putString("font.com.example.app.hook_domains", "textview_sp")
+                .commit();
+        DpiConfigStore store = new DpiConfigStore(prefs);
+
+        assertEquals("textview_sp", store.getPackageFontHookDomainsRaw("com.example.app"));
+    }
+
+    @Test
+    public void configuredPackagesIncludeMixedLegacyAndAggregatedHookDomainState() {
+        FakePrefs prefs = new FakePrefs();
+        prefs.edit()
+                .putString("font.com.example.legacy.hook_domains", "textview_sp")
+                .putString("package_config.com.example.aggregated.font.hook_domains",
+                        "resources_font")
+                .commit();
+        DpiConfigStore store = new DpiConfigStore(prefs);
+
+        assertTrue(store.getConfiguredPackages().contains("com.example.legacy"));
+        assertTrue(store.getConfiguredPackages().contains("com.example.aggregated"));
+        assertTrue(store.hasUserVisiblePackageConfig("com.example.legacy"));
+        assertTrue(store.hasUserVisiblePackageConfig("com.example.aggregated"));
     }
 
     @Test
@@ -225,8 +545,47 @@ public class DpiConfigStoreTest {
         assertTrue(store.setWechatDpi("com.tencent.mm", 360));
 
         assertEquals(Integer.valueOf(360), store.getWechatDpi("com.tencent.mm"));
+        assertEquals(Integer.valueOf(360),
+                Integer.valueOf(prefs.getInt("wechat.com.tencent.mm.dpi", 0)));
+        assertEquals(Integer.valueOf(360),
+                Integer.valueOf(prefs.getInt(
+                        "package_config.com.tencent.mm.app.wechat_dpi", 0)));
         assertTrue(store.hasTargetAppSpecificConfig("com.tencent.mm"));
         assertTrue(store.getConfiguredPackages().contains("com.tencent.mm"));
+    }
+
+    @Test
+    public void dpisEnabledReadsAggregatedDisabledOverride() {
+        FakePrefs prefs = new FakePrefs();
+        prefs.edit()
+                .putBoolean("package_config.com.example.app.target.dpis_enabled", false)
+                .commit();
+        DpiConfigStore store = new DpiConfigStore(prefs);
+
+        assertFalse(store.isTargetDpisEnabled("com.example.app"));
+        assertTrue(store.getConfiguredPackages().contains("com.example.app"));
+        assertTrue(store.hasUserVisiblePackageConfig("com.example.app"));
+    }
+
+    @Test
+    public void dpisEnabledSetterWritesAndClearsLegacyAndAggregatedKeys() {
+        FakePrefs prefs = new FakePrefs();
+        DpiConfigStore store = new DpiConfigStore(prefs);
+
+        assertTrue(store.setTargetDpisEnabled("com.example.app", false));
+
+        assertFalse(store.isTargetDpisEnabled("com.example.app"));
+        assertFalse(prefs.getBoolean("target.com.example.app.dpis_enabled", true));
+        assertFalse(prefs.getBoolean(
+                "package_config.com.example.app.target.dpis_enabled", true));
+        assertTrue(store.getConfiguredPackages().contains("com.example.app"));
+
+        assertTrue(store.setTargetDpisEnabled("com.example.app", true));
+
+        assertTrue(store.isTargetDpisEnabled("com.example.app"));
+        assertFalse(prefs.contains("target.com.example.app.dpis_enabled"));
+        assertFalse(prefs.contains("package_config.com.example.app.target.dpis_enabled"));
+        assertFalse(store.getConfiguredPackages().contains("com.example.app"));
     }
 
     @Test
@@ -238,7 +597,36 @@ public class DpiConfigStoreTest {
         assertTrue(store.clearWechatDpi("com.tencent.mm"));
 
         assertNull(store.getWechatDpi("com.tencent.mm"));
+        assertFalse(prefs.contains("wechat.com.tencent.mm.dpi"));
+        assertFalse(prefs.contains("package_config.com.tencent.mm.app.wechat_dpi"));
         assertFalse(store.getConfiguredPackages().contains("com.tencent.mm"));
+    }
+
+    @Test
+    public void wechatDpiGetterReadsAggregatedKey() {
+        FakePrefs prefs = new FakePrefs();
+        prefs.edit()
+                .putInt("package_config.com.tencent.mm.app.wechat_dpi", 600)
+                .commit();
+        DpiConfigStore store = new DpiConfigStore(prefs);
+
+        assertEquals(Integer.valueOf(600), store.getWechatDpi("com.tencent.mm"));
+        assertTrue(store.hasTargetAppSpecificConfig("com.tencent.mm"));
+        assertTrue(store.getConfiguredPackages().contains("com.tencent.mm"));
+        assertTrue(store.hasUserVisiblePackageConfig("com.tencent.mm"));
+    }
+
+    @Test
+    public void aggregatedWechatDpiIgnoredForUnsupportedPackage() {
+        FakePrefs prefs = new FakePrefs();
+        prefs.edit()
+                .putInt("package_config.com.example.app.app.wechat_dpi", 600)
+                .commit();
+        DpiConfigStore store = new DpiConfigStore(prefs);
+
+        assertNull(store.getWechatDpi("com.example.app"));
+        assertFalse(store.getConfiguredPackages().contains("com.example.app"));
+        assertFalse(store.hasUserVisiblePackageConfig("com.example.app"));
     }
 
     @Test
@@ -254,6 +642,9 @@ public class DpiConfigStoreTest {
         assertEquals(Integer.valueOf(360), store.getWechatDpi("com.tencent.mm"));
         assertTrue(store.getConfiguredPackages().contains("com.tencent.mm"));
         assertFalse(prefs.contains("wechat.com.tencent.mm.wekit_dpi"));
+        assertEquals(Integer.valueOf(360),
+                Integer.valueOf(prefs.getInt(
+                        "package_config.com.tencent.mm.app.wechat_dpi", 0)));
     }
 
     @Test
@@ -312,6 +703,8 @@ public class DpiConfigStoreTest {
         assertTrue(store.clearTargetFontScalePercent("bin.mt.plus.canary"));
 
         assertNull(store.getTargetFontScalePercent("bin.mt.plus.canary"));
+        assertFalse(prefs.contains("font.bin.mt.plus.canary.scale_percent"));
+        assertFalse(prefs.contains("package_config.bin.mt.plus.canary.font.scale_percent"));
         assertFalse(store.getConfiguredPackages().contains("bin.mt.plus.canary"));
     }
 
@@ -324,6 +717,8 @@ public class DpiConfigStoreTest {
 
         assertEquals("font_abcd1234", store.getTargetTypefaceId("bin.mt.plus.canary"));
         assertTrue(store.hasPrimaryTargetTypefaceId("bin.mt.plus.canary"));
+        assertEquals("font_abcd1234",
+                prefs.getString("package_config.bin.mt.plus.canary.font.typeface_id", null));
         assertTrue(store.getConfiguredPackages().contains("bin.mt.plus.canary"));
     }
 
@@ -337,6 +732,8 @@ public class DpiConfigStoreTest {
 
         assertNull(store.getTargetTypefaceId("bin.mt.plus.canary"));
         assertFalse(store.hasPrimaryTargetTypefaceId("bin.mt.plus.canary"));
+        assertFalse(prefs.contains("font.bin.mt.plus.canary.typeface_id"));
+        assertFalse(prefs.contains("package_config.bin.mt.plus.canary.font.typeface_id"));
         assertFalse(store.getConfiguredPackages().contains("bin.mt.plus.canary"));
     }
 
@@ -435,10 +832,14 @@ public class DpiConfigStoreTest {
         assertTrue(store.setTargetFontApplyMode("bin.mt.plus.canary", FontApplyMode.FIELD_REWRITE));
         assertEquals(FontApplyMode.FIELD_REWRITE,
                 store.getTargetFontApplyMode("bin.mt.plus.canary"));
+        assertEquals(FontApplyMode.FIELD_REWRITE,
+                prefs.getString("package_config.bin.mt.plus.canary.font.mode", null));
 
         assertTrue(store.setTargetFontApplyMode("bin.mt.plus.canary", FontApplyMode.OFF));
         assertEquals(FontApplyMode.SYSTEM_EMULATION,
                 store.getTargetFontApplyMode("bin.mt.plus.canary"));
+        assertFalse(prefs.contains("font.bin.mt.plus.canary.mode"));
+        assertFalse(prefs.contains("package_config.bin.mt.plus.canary.font.mode"));
     }
 
     @Test
@@ -1065,6 +1466,305 @@ public class DpiConfigStoreTest {
     }
 
     @Test
+    public void packageTemplateConfigDoesNotCopyNonTemplateFields() {
+        FakePrefs prefs = new FakePrefs();
+        DpiConfigStore store = new DpiConfigStore(prefs);
+        assertTrue(store.writePackageConfig("com.tencent.mm", new PackageConfigValue(
+                ViewportTargetSpec.relativeScale(1200),
+                ViewportTargetType.RELATIVE_SCALE,
+                ViewportApplyMode.SYSTEM,
+                130,
+                FontApplyMode.FIELD_REWRITE,
+                "test_font",
+                "resources_font",
+                false,
+                600)));
+
+        TemplateConfigValue template = store.readPackageTemplateConfigValue("com.tencent.mm");
+        assertTrue(store.writePackageTemplateConfigValue("com.example.target", template));
+
+        assertEquals(Integer.valueOf(130), store.getTargetFontScalePercent("com.example.target"));
+        assertEquals("test_font", store.getTargetTypefaceId("com.example.target"));
+        assertTrue(store.isTargetDpisEnabled("com.example.target"));
+        assertNull(store.getWechatDpi("com.example.target"));
+        assertFalse(prefs.contains("target.com.example.target.dpis_enabled"));
+        assertFalse(prefs.contains("package_config.com.example.target.target.dpis_enabled"));
+        assertFalse(prefs.contains("wechat.com.example.target.dpi"));
+        assertFalse(prefs.contains("package_config.com.example.target.app.wechat_dpi"));
+    }
+
+    @Test
+    public void packageTemplateWriteDoesNotOverwriteExistingNonTemplateFields() {
+        FakePrefs prefs = new FakePrefs();
+        DpiConfigStore store = new DpiConfigStore(prefs);
+        assertTrue(store.writePackageConfig("com.tencent.mm", new PackageConfigValue(
+                ViewportTargetSpec.absoluteDp(411),
+                ViewportTargetType.ABSOLUTE_DP,
+                ViewportApplyMode.SYSTEM,
+                null,
+                FontApplyMode.OFF,
+                null,
+                null,
+                false,
+                600)));
+
+        assertTrue(store.writePackageTemplateConfigValue("com.tencent.mm", new TemplateConfigValue(
+                ViewportTargetSpec.relativeScale(1150),
+                ViewportApplyMode.AUTO,
+                125,
+                FontApplyMode.FIELD_REWRITE,
+                "new_font",
+                "textview_sp")));
+
+        assertFalse(store.isTargetDpisEnabled("com.tencent.mm"));
+        assertEquals(Integer.valueOf(600), store.getWechatDpi("com.tencent.mm"));
+        assertEquals(Integer.valueOf(125), store.getTargetFontScalePercent("com.tencent.mm"));
+        assertEquals("new_font", store.getTargetTypefaceId("com.tencent.mm"));
+    }
+
+    @Test
+    public void readPackageConfigAggregatesCurrentScatteredKeys() {
+        FakePrefs prefs = new FakePrefs();
+        prefs.edit()
+                .putStringSet(DpiConfigStore.KEY_TARGET_PACKAGES,
+                        new LinkedHashSet<>(Set.of("com.tencent.mm")))
+                .putString("viewport.com.tencent.mm.target_type",
+                        ViewportTargetType.RELATIVE_SCALE)
+                .putInt("viewport.com.tencent.mm.scale_permille", 1250)
+                .putString("viewport.com.tencent.mm.mode",
+                        ViewportApplyMode.SYSTEM)
+                .putInt("font.com.tencent.mm.scale_percent", 140)
+                .putString("font.com.tencent.mm.mode",
+                        FontApplyMode.FIELD_REWRITE)
+                .putString("font.com.tencent.mm.typeface_id", "test_font")
+                .putString("font.com.tencent.mm.hook_domains", "resources_font,textview_sp")
+                .putBoolean("target.com.tencent.mm.dpis_enabled", false)
+                .putInt("wechat.com.tencent.mm.dpi", 600)
+                .commit();
+        DpiConfigStore store = new DpiConfigStore(prefs);
+
+        PackageConfigValue value = store.readPackageConfig("com.tencent.mm");
+
+        assertEquals(new PackageConfigValue(
+                ViewportTargetSpec.relativeScale(1250),
+                ViewportTargetType.RELATIVE_SCALE,
+                ViewportApplyMode.SYSTEM,
+                140,
+                FontApplyMode.FIELD_REWRITE,
+                "test_font",
+                "resources_font,textview_sp",
+                false,
+                600), value);
+    }
+
+    @Test
+    public void readPackageConfigAggregatesNewPackageConfigKeys() {
+        FakePrefs prefs = new FakePrefs();
+        prefs.edit()
+                .putString("package_config.com.tencent.mm.viewport.target_type",
+                        ViewportTargetType.RELATIVE_SCALE)
+                .putInt("package_config.com.tencent.mm.viewport.scale_permille", 1250)
+                .putString("package_config.com.tencent.mm.viewport.mode",
+                        ViewportApplyMode.SYSTEM)
+                .putInt("package_config.com.tencent.mm.font.scale_percent", 140)
+                .putString("package_config.com.tencent.mm.font.mode",
+                        FontApplyMode.FIELD_REWRITE)
+                .putString("package_config.com.tencent.mm.font.typeface_id", "test_font")
+                .putString("package_config.com.tencent.mm.font.hook_domains",
+                        "resources_font,textview_sp")
+                .putBoolean("package_config.com.tencent.mm.target.dpis_enabled", false)
+                .putInt("package_config.com.tencent.mm.app.wechat_dpi", 600)
+                .commit();
+        DpiConfigStore store = new DpiConfigStore(prefs);
+
+        PackageConfigValue value = store.readPackageConfig("com.tencent.mm");
+
+        assertEquals(new PackageConfigValue(
+                ViewportTargetSpec.relativeScale(1250),
+                ViewportTargetType.RELATIVE_SCALE,
+                ViewportApplyMode.SYSTEM,
+                140,
+                FontApplyMode.FIELD_REWRITE,
+                "test_font",
+                "resources_font,textview_sp",
+                false,
+                600), value);
+        assertEquals(Integer.valueOf(140), store.getTargetFontScalePercent("com.tencent.mm"));
+        assertFalse(store.isTargetDpisEnabled("com.tencent.mm"));
+        assertTrue(store.getConfiguredPackages().contains("com.tencent.mm"));
+        assertTrue(store.hasUserVisiblePackageConfig("com.tencent.mm"));
+    }
+
+    @Test
+    public void legacyGettersDoNotResurrectClearedValuesFromAggregatedResidue() {
+        FakePrefs prefs = new FakePrefs();
+        DpiConfigStore store = new DpiConfigStore(prefs);
+        assertTrue(store.writePackageConfig("com.tencent.mm", new PackageConfigValue(
+                ViewportTargetSpec.absoluteDp(411),
+                ViewportTargetType.ABSOLUTE_DP,
+                ViewportApplyMode.SYSTEM,
+                135,
+                FontApplyMode.FIELD_REWRITE,
+                "test_font",
+                "resources_font",
+                false,
+                700)));
+
+        assertTrue(store.clearTargetViewportWidthDp("com.tencent.mm"));
+        assertTrue(store.clearTargetFontScalePercent("com.tencent.mm"));
+        assertTrue(store.clearTargetTypefaceId("com.tencent.mm"));
+        assertTrue(store.clearPackageFontHookDomainsRaw("com.tencent.mm"));
+        assertTrue(store.clearWechatDpi("com.tencent.mm"));
+        assertTrue(store.setTargetDpisEnabled("com.tencent.mm", true));
+
+        assertNull(store.getTargetViewportWidthDp("com.tencent.mm"));
+        assertNull(store.getTargetFontScalePercent("com.tencent.mm"));
+        assertNull(store.getTargetTypefaceId("com.tencent.mm"));
+        assertNull(store.getPackageFontHookDomainsRaw("com.tencent.mm"));
+        assertNull(store.getWechatDpi("com.tencent.mm"));
+        assertTrue(store.isTargetDpisEnabled("com.tencent.mm"));
+        assertTrue(store.readPackageConfig("com.tencent.mm").hasAnyValue());
+        assertTrue(store.hasUserVisiblePackageConfig("com.tencent.mm"));
+    }
+
+    @Test
+    public void writePackageConfigPersistsSparseLegacyAndAggregatedKeys() {
+        FakePrefs prefs = new FakePrefs();
+        DpiConfigStore store = new DpiConfigStore(prefs);
+
+        assertTrue(store.writePackageConfig("com.tencent.mm", new PackageConfigValue(
+                ViewportTargetSpec.absoluteDp(411),
+                ViewportTargetType.RELATIVE_SCALE,
+                ViewportApplyMode.SYSTEM,
+                135,
+                FontApplyMode.FIELD_REWRITE,
+                "test_font",
+                "resources_font",
+                false,
+                700)));
+
+        assertEquals(Integer.valueOf(411), store.getTargetViewportWidthDp("com.tencent.mm"));
+        assertEquals(ViewportTargetType.ABSOLUTE_DP, store.getTargetViewportType("com.tencent.mm"));
+        assertEquals(ViewportApplyMode.SYSTEM,
+                prefs.getString("viewport.com.tencent.mm.mode", null));
+        assertEquals(Integer.valueOf(135), store.getTargetFontScalePercent("com.tencent.mm"));
+        assertEquals(FontApplyMode.FIELD_REWRITE,
+                prefs.getString("font.com.tencent.mm.mode", null));
+        assertEquals("test_font", store.getTargetTypefaceId("com.tencent.mm"));
+        assertEquals("resources_font", store.getPackageFontHookDomainsRaw("com.tencent.mm"));
+        assertFalse(store.isTargetDpisEnabled("com.tencent.mm"));
+        assertEquals(Integer.valueOf(700), store.getWechatDpi("com.tencent.mm"));
+        assertTrue(store.getConfiguredPackages().contains("com.tencent.mm"));
+        assertEquals(Integer.valueOf(411),
+                Integer.valueOf(prefs.getInt(
+                        "package_config.com.tencent.mm.viewport.width_dp", 0)));
+        assertEquals(Integer.valueOf(135),
+                Integer.valueOf(prefs.getInt(
+                        "package_config.com.tencent.mm.font.scale_percent", 0)));
+        assertEquals("test_font",
+                prefs.getString("package_config.com.tencent.mm.font.typeface_id", null));
+        assertFalse(prefs.getBoolean(
+                "package_config.com.tencent.mm.target.dpis_enabled", true));
+        assertEquals(Integer.valueOf(700),
+                Integer.valueOf(prefs.getInt(
+                        "package_config.com.tencent.mm.app.wechat_dpi", 0)));
+    }
+
+    @Test
+    public void writePackageConfigReplacesOldDataWithNewAndLegacyMirrors() {
+        FakePrefs prefs = new FakePrefs();
+        prefs.edit()
+                .putString("viewport.com.tencent.mm.target_type",
+                        ViewportTargetType.ABSOLUTE_DP)
+                .putInt("viewport.com.tencent.mm.width_dp", 400)
+                .putString("package_config.com.tencent.mm.viewport.target_type",
+                        ViewportTargetType.RELATIVE_SCALE)
+                .putInt("package_config.com.tencent.mm.viewport.scale_permille", 1200)
+                .putString("package_config.com.tencent.mm.font.typeface_id", "old_font")
+                .commit();
+        DpiConfigStore store = new DpiConfigStore(prefs);
+
+        assertTrue(store.writePackageConfig("com.tencent.mm", new PackageConfigValue(
+                ViewportTargetSpec.relativeScale(1300),
+                ViewportTargetType.RELATIVE_SCALE,
+                ViewportApplyMode.SYSTEM,
+                145,
+                FontApplyMode.FIELD_REWRITE,
+                "new_font",
+                "textview_sp",
+                false,
+                650)));
+
+        assertFalse(prefs.contains("viewport.com.tencent.mm.width_dp"));
+        assertEquals(ViewportTargetType.RELATIVE_SCALE,
+                prefs.getString("viewport.com.tencent.mm.target_type", null));
+        assertEquals(Integer.valueOf(1300),
+                Integer.valueOf(prefs.getInt("viewport.com.tencent.mm.scale_permille", 0)));
+        assertEquals(Integer.valueOf(1300),
+                Integer.valueOf(prefs.getInt(
+                        "package_config.com.tencent.mm.viewport.scale_permille", 0)));
+        assertFalse(prefs.contains("package_config.com.tencent.mm.viewport.width_dp"));
+        assertEquals("new_font", store.getTargetTypefaceId("com.tencent.mm"));
+        assertFalse(store.isTargetDpisEnabled("com.tencent.mm"));
+        assertEquals(Integer.valueOf(650), store.getWechatDpi("com.tencent.mm"));
+    }
+
+    @Test
+    public void configuredPackagesAndVisibilityIncludeMixedLegacyAndAggregatedState() {
+        FakePrefs prefs = new FakePrefs();
+        prefs.edit()
+                .putString("font.com.example.legacy.mode", FontApplyMode.FIELD_REWRITE)
+                .putBoolean("package_config.com.example.disabled.target.dpis_enabled", false)
+                .putString("package_config.com.example.domains.font.hook_domains",
+                        "resources_font")
+                .commit();
+        DpiConfigStore store = new DpiConfigStore(prefs);
+
+        assertTrue(store.getConfiguredPackages().contains("com.example.legacy"));
+        assertTrue(store.getConfiguredPackages().contains("com.example.disabled"));
+        assertTrue(store.getConfiguredPackages().contains("com.example.domains"));
+        assertTrue(store.hasUserVisiblePackageConfig("com.example.legacy"));
+        assertTrue(store.hasUserVisiblePackageConfig("com.example.disabled"));
+        assertTrue(store.hasUserVisiblePackageConfig("com.example.domains"));
+    }
+
+    @Test
+    public void writeEmptyPackageConfigClearsKnownLegacyAndAggregatedKeysAndPrunesPackage() {
+        FakePrefs prefs = new FakePrefs();
+        prefs.edit()
+                .putStringSet(DpiConfigStore.KEY_TARGET_PACKAGES,
+                        new LinkedHashSet<>(Set.of("com.tencent.mm")))
+                .putString("viewport.com.tencent.mm.target_type",
+                        ViewportTargetType.ABSOLUTE_DP)
+                .putInt("viewport.com.tencent.mm.width_dp", 400)
+                .putString("font.com.tencent.mm.typeface_id", "test_font")
+                .putBoolean("target.com.tencent.mm.dpis_enabled", false)
+                .putInt("wechat.com.tencent.mm.dpi", 600)
+                .putString("package_config.com.tencent.mm.viewport.target_type",
+                        ViewportTargetType.ABSOLUTE_DP)
+                .putInt("package_config.com.tencent.mm.viewport.width_dp", 400)
+                .putString("package_config.com.tencent.mm.font.typeface_id", "test_font")
+                .putBoolean("package_config.com.tencent.mm.target.dpis_enabled", false)
+                .putInt("package_config.com.tencent.mm.app.wechat_dpi", 600)
+                .commit();
+        DpiConfigStore store = new DpiConfigStore(prefs);
+
+        assertTrue(store.writePackageConfig("com.tencent.mm", PackageConfigValue.EMPTY));
+
+        assertFalse(store.getConfiguredPackages().contains("com.tencent.mm"));
+        assertFalse(prefs.contains("viewport.com.tencent.mm.target_type"));
+        assertFalse(prefs.contains("viewport.com.tencent.mm.width_dp"));
+        assertFalse(prefs.contains("font.com.tencent.mm.typeface_id"));
+        assertFalse(prefs.contains("target.com.tencent.mm.dpis_enabled"));
+        assertFalse(prefs.contains("wechat.com.tencent.mm.dpi"));
+        assertFalse(prefs.contains("package_config.com.tencent.mm.viewport.target_type"));
+        assertFalse(prefs.contains("package_config.com.tencent.mm.viewport.width_dp"));
+        assertFalse(prefs.contains("package_config.com.tencent.mm.font.typeface_id"));
+        assertFalse(prefs.contains("package_config.com.tencent.mm.target.dpis_enabled"));
+        assertFalse(prefs.contains("package_config.com.tencent.mm.app.wechat_dpi"));
+    }
+
+    @Test
     public void emptyPackageTemplateConfigValuePreservesDisabledStateAndMembership() {
         FakePrefs prefs = new FakePrefs();
         DpiConfigStore store = new DpiConfigStore(prefs);
@@ -1080,6 +1780,26 @@ public class DpiConfigStoreTest {
         assertNull(store.getTargetViewportWidthDp("com.example.app"));
         assertNull(store.getTargetTypefaceId("com.example.app"));
         assertTrue(prefs.contains("target.com.example.app.dpis_enabled"));
+        assertTrue(prefs.contains("package_config.com.example.app.target.dpis_enabled"));
+    }
+
+    @Test
+    public void emptyPackageTemplateConfigValuePreservesWechatDpiAndMembership() {
+        FakePrefs prefs = new FakePrefs();
+        DpiConfigStore store = new DpiConfigStore(prefs);
+        assertTrue(store.setWechatDpi("com.tencent.mm", 600));
+        assertTrue(store.setTargetViewportWidthDp("com.tencent.mm", 411));
+        assertTrue(store.setTargetTypefaceId("com.tencent.mm", "missing_font_id"));
+
+        assertTrue(store.writePackageTemplateConfigValue(
+                "com.tencent.mm", TemplateConfigValue.EMPTY));
+
+        assertEquals(Integer.valueOf(600), store.getWechatDpi("com.tencent.mm"));
+        assertTrue(store.getConfiguredPackages().contains("com.tencent.mm"));
+        assertNull(store.getTargetViewportWidthDp("com.tencent.mm"));
+        assertNull(store.getTargetTypefaceId("com.tencent.mm"));
+        assertTrue(prefs.contains("wechat.com.tencent.mm.dpi"));
+        assertTrue(prefs.contains("package_config.com.tencent.mm.app.wechat_dpi"));
     }
 
     private static final class ThrowingIntReadPrefs implements SharedPreferences {

--- a/app/src/test/java/com/dpis/module/QuickTemplateApplyCoordinatorTest.java
+++ b/app/src/test/java/com/dpis/module/QuickTemplateApplyCoordinatorTest.java
@@ -102,6 +102,39 @@ public class QuickTemplateApplyCoordinatorTest {
     }
 
     @Test
+    public void storeBackedApplyUsesPackageTemplateAdapterOnly() {
+        FakePrefs prefs = new FakePrefs();
+        DpiConfigStore store = new DpiConfigStore(prefs);
+        assertTrue(store.writePackageConfig("com.tencent.mm", new PackageConfigValue(
+                ViewportTargetSpec.relativeScale(1200),
+                ViewportTargetType.RELATIVE_SCALE,
+                ViewportApplyMode.SYSTEM,
+                130,
+                FontApplyMode.FIELD_REWRITE,
+                "source_font",
+                "resources_font",
+                false,
+                600)));
+        QuickTemplateApplyCoordinator coordinator = new QuickTemplateApplyCoordinator(
+                store);
+
+        QuickTemplateApplyCoordinator.Result result = coordinator.apply(template(
+                orderedSet("com.example.target"),
+                store.readPackageTemplateConfigValue("com.tencent.mm")));
+
+        assertEquals(1, result.successCount());
+        assertEquals(Integer.valueOf(130),
+                store.getTargetFontScalePercent("com.example.target"));
+        assertEquals("source_font", store.getTargetTypefaceId("com.example.target"));
+        assertTrue(store.isTargetDpisEnabled("com.example.target"));
+        assertNull(store.getWechatDpi("com.example.target"));
+        assertFalse(prefs.contains("target.com.example.target.dpis_enabled"));
+        assertFalse(prefs.contains("package_config.com.example.target.target.dpis_enabled"));
+        assertFalse(prefs.contains("wechat.com.example.target.dpi"));
+        assertFalse(prefs.contains("package_config.com.example.target.app.wechat_dpi"));
+    }
+
+    @Test
     public void runtimePublishPlanMirrorsSingleAppSaveForEnabledTemplateValues() {
         QuickTemplateApplyCoordinator.RuntimePublishPlan plan =
                 QuickTemplateApplyCoordinator.RuntimePublishPlan.from(

--- a/app/src/test/java/com/dpis/module/QuickTemplateTargetSelectionSourceSmokeTest.java
+++ b/app/src/test/java/com/dpis/module/QuickTemplateTargetSelectionSourceSmokeTest.java
@@ -39,8 +39,10 @@ public class QuickTemplateTargetSelectionSourceSmokeTest {
         assertTrue(targetsBinder.contains("quickTemplateStore.setSelectedPackages(template.id, selectedPackages)"));
         assertTrue(targetsBinder.contains("pruneSelectedPackagesToInstalledApps(selectedPackages, allTargetItems)"));
         assertTrue(targetsBinder.contains("DpisApplication.getActiveHookConfigStore(activity)"));
+        assertTrue(targetsBinder.contains("new PackageConfigRepository("));
         assertTrue(targetsBinder.contains("installedAppCatalogCoordinator.loadInstalledAppCatalog(false)"));
-        assertTrue(targetsBinder.contains("configStore.hasRealPackageConfig(item.packageName)"));
+        assertTrue(targetsBinder.contains(
+                "packageConfigRepository.hasRealPackageConfig(item.packageName)"));
         assertTrue(targetsBinder.contains("FILTER_PREFS_NAME = \"quick_template_target_filters\""));
         assertTrue(targetsBinder.contains("KEY_FILTER_SHOW_SYSTEM_APPS"));
         assertTrue(targetsBinder.contains("KEY_FILTER_HIDE_CONFIGURED_APPS"));

--- a/app/src/test/java/com/dpis/module/RuntimePropertyRecoveryCoordinatorSourceTest.java
+++ b/app/src/test/java/com/dpis/module/RuntimePropertyRecoveryCoordinatorSourceTest.java
@@ -26,6 +26,10 @@ public final class RuntimePropertyRecoveryCoordinatorSourceTest {
         assertTrue(source.contains("idempotent"));
         assertTrue(app.contains("RuntimePropertyRecoveryCoordinator.resyncConfiguredTargetsAsync(configStore)"));
         assertTrue(app.contains("RuntimePropertyRecoveryCoordinator.resyncConfiguredTargetsAsync(refreshedStore)"));
+        assertTrue(app.contains("migrateLocalConfigStore(configStore)"));
+        assertTrue(app.contains("migrateLocalConfigStore(localStore)"));
+        assertTrue(app.contains("store.migrateLegacyWechatDpi()"));
+        assertTrue(app.contains("store.migrateLegacyPackageConfigToAggregated()"));
         assertTrue(receiver.contains("best-effort triggers"));
         assertTrue(receiver.contains("RuntimePropertyRecoveryCoordinator.resyncConfiguredTargetsAsync(store)"));
     }


### PR DESCRIPTION
## 概述

本分支围绕 per-app 配置的存储、迁移、展示语义和备份格式做了一轮收口。核心目标是把“每个应用的配置”从历史上的散落键值迁移到统一、可解释、可扩展的结构，并让 UI、备份和恢复流程都围绕同一套语义工作。

## 主要改动

### 1. 引入统一的 per-app 配置来源

新增 `package_config.<pkg>.*` 作为按包名聚合的 per-app 配置来源，用来承载应用级的 viewport、font、target、wechat 等配置。历史上的散落键：

- `viewport.<pkg>.*`
- `font.<pkg>.*`
- `target.<pkg>.*`
- `wechat.<pkg>.*`

不再作为长期存储模型保留。

### 2. 实现旧配置自动迁移

旧版散 key 会在以下时机自动迁移到新的 `package_config.<pkg>.*`：

- 应用启动
- 服务绑定
- 配置重载
- 备份恢复

迁移规则为：

- 新格式优先
- 若新旧同时存在，保留新格式
- 迁移完成后清理旧散 key
- `target_packages` 不再作为配置来源，只保留兼容/过渡意义

这样可以保证老用户升级后无需手动整理配置。

### 3. 收紧“已配置应用”的语义

已配置应用的判定改为基于**用户可见的真实保存状态**，不再因为默认值、空模板、重置残留或中间态而被错误计入。  
同时保留“已卸载但仍有用户配置”的应用配置，使其继续出现在已配置列表中并允许完整编辑，符合“这是用户主动保留的 per-app 偏好”的语义。

### 4. 结构化备份格式升级到 `schemaVersion = 3`

备份导出不再继续使用“一个大 `entries` + 部分例外”的形式，而是升级为按配置归属分区的结构化格式：

- `packageConfigs`
- `resolutionConfigs`
- `global`
- `defaultPrefill`
- `templates`

其中：

- `packageConfigs` 以包名为主体，按 `viewport` / `font` / `target` / `app` 分组
- `resolutionConfigs` 也按包名聚合，避免 `resolution.<pkg>.*` 落入全局区
- `defaultPrefill` 承载全局预填
- `templates` 以 template id 为主体，模板元信息放在 `_meta`
- 所有新分区直接存 JSON 原值，不再使用 `type/value` 包装

### 5. 保持旧备份导入兼容

虽然导出只写 `schemaVersion = 3`，但导入仍兼容：

- `schemaVersion = 1`
- `schemaVersion = 2`
- `schemaVersion = 3`

解码后统一还原成现有恢复流程使用的 flat `Map<String, Object>`，从而避免扩大 restore 链路的改动范围。

### 6. 去掉误导性的备份项数提示

旧实现里导入/导出成功提示使用的是内部键数量。  
这在 v1/v2/v3 三种备份结构之间并不等价，会出现“旧备份导入 24 项、重新导出 19 项”这类对用户无意义且容易误解的数字。

现在成功提示改为直接表达动作结果：

- `已导出备份`
- `已导入备份`

不再暴露内部计数。

## 效果

经过这轮调整后：

- per-app 配置不再散落在多处
- 老用户配置可以自动升级到新结构
- 已配置应用列表的语义更稳定
- 备份文件更接近“按包名和领域组织配置”的可读结构
- 导入导出提示不再被内部实现细节污染
