### PR TITLE
fix(app-list): hide system scope from configured apps

### DIFF
--- a/app/src/main/java/com/dpis/module/SystemServerSettingsPageController.java
+++ b/app/src/main/java/com/dpis/module/SystemServerSettingsPageController.java
@@ -20,6 +20,7 @@ import com.dpis.module.settings.AppUiScaleManager;
 import com.dpis.module.settings.InterfaceScaleStore;
 import com.dpis.module.settings.LauncherIconVisibilityStore;
 import com.dpis.module.settings.SafeCacheCleaner;
+import com.dpis.module.settings.SystemFrameworkScope;
 import com.dpis.module.settings.SystemHookState;
 import com.dpis.module.settings.SystemHooksToggleController;
 import com.dpis.module.settings.ExperimentalSettingsActivity;
@@ -77,7 +78,6 @@ import io.github.libxposed.service.XposedService;
 
 final class SystemServerSettingsPageController implements DpisApplication.ServiceStateListener {
     private static final long STATS_REFRESH_INTERVAL_MS = 500L;
-    private static final String SYSTEM_SCOPE_MODERN = "system";
     private static final int REQUEST_EXPORT_CONFIG_BACKUP = 1001;
     private static final int REQUEST_IMPORT_CONFIG_BACKUP = 1002;
     private static final long CLEAR_CACHE_MIN_DISABLED_MS = 300L;
@@ -1376,7 +1376,7 @@ final class SystemServerSettingsPageController implements DpisApplication.Servic
             }
             try {
                 List<String> scope = service.getScope();
-                return scope != null && scope.contains(SYSTEM_SCOPE_MODERN);
+                return SystemFrameworkScope.containsSystemScope(scope);
             } catch (RuntimeException error) {
                 return false;
             }

--- a/app/src/main/java/com/dpis/module/applist/InstalledAppCatalogCoordinator.kt
+++ b/app/src/main/java/com/dpis/module/applist/InstalledAppCatalogCoordinator.kt
@@ -10,6 +10,7 @@ import android.os.SystemClock
 import com.dpis.module.DpisConfigStore
 import com.dpis.module.DpisLog
 import com.dpis.module.fonts.FontApplyMode
+import com.dpis.module.settings.SystemFrameworkScope
 import com.dpis.module.viewport.ViewportApplyMode
 import com.dpis.module.viewport.ViewportTargetSpec
 import com.dpis.module.viewport.ViewportTargetType
@@ -206,7 +207,10 @@ class InstalledAppCatalogCoordinator(
         fun userVisibleConfiguredPackages(store: DpisConfigStore?): Set<String> {
             if (store == null) return emptySet()
             return store.configuredPackages
-                .filterTo(HashSet()) { store.hasUserVisiblePackageConfig(it) }
+                .filterTo(HashSet()) {
+                    !SystemFrameworkScope.isFrameworkScopePackage(it) &&
+                        store.hasUserVisiblePackageConfig(it)
+                }
         }
 
         /**
@@ -222,7 +226,8 @@ class InstalledAppCatalogCoordinator(
         ): Set<String> {
             val configured = userVisibleConfiguredPackages(store).toMutableSet()
             if (scopeKnown) {
-                configured.addAll(scopePackages.orEmpty())
+                scopePackages.orEmpty()
+                    .filterNotTo(configured) { SystemFrameworkScope.isFrameworkScopePackage(it) }
             }
             return configured
         }
@@ -253,7 +258,12 @@ class InstalledAppCatalogCoordinator(
             false,
             null,
             true,
-            scopeKnown && inScope,
+            isUserVisibleConfiguredPackage(
+                null,
+                packageName,
+                scopeKnown,
+                inScope,
+            ),
             installed,
             systemApp,
             hyperOsNativeProxyCandidate,
@@ -321,7 +331,8 @@ class InstalledAppCatalogCoordinator(
             scopeKnown: Boolean,
             inScope: Boolean,
         ): Boolean =
-            (scopeKnown && inScope) || store?.hasUserVisiblePackageConfig(packageName) == true
+            !SystemFrameworkScope.isFrameworkScopePackage(packageName) &&
+                ((scopeKnown && inScope) || store?.hasUserVisiblePackageConfig(packageName) == true)
 
         @JvmStatic
         fun shouldUseLauncherVisibilityFallback(

--- a/app/src/main/java/com/dpis/module/settings/SystemFrameworkScope.java
+++ b/app/src/main/java/com/dpis/module/settings/SystemFrameworkScope.java
@@ -1,0 +1,32 @@
+package com.dpis.module.settings;
+
+import java.util.Collection;
+
+/** Shared semantics for LSPosed/Xposed system-framework scope entries. */
+public final class SystemFrameworkScope {
+    public static final String SYSTEM_SCOPE_MODERN = "system";
+    public static final String SYSTEM_SCOPE_ANDROID_ALIAS = "android";
+
+    private SystemFrameworkScope() {
+    }
+
+    /**
+     * System-framework scope entries enable DPIS system_server hooks, but they are
+     * not user app targets and must not appear in configured-app lists or counts.
+     */
+    public static boolean isFrameworkScopePackage(String packageName) {
+        return SYSTEM_SCOPE_MODERN.equals(packageName)
+                || SYSTEM_SCOPE_ANDROID_ALIAS.equals(packageName);
+    }
+
+    /**
+     * Modern LSPosed reports system_server scope as "system". Some legacy/Xposed
+     * surfaces expose the Android framework package name instead, so accept both
+     * aliases when resolving whether the system hook is selected.
+     */
+    public static boolean containsSystemScope(Collection<String> scopePackages) {
+        return scopePackages != null
+                && (scopePackages.contains(SYSTEM_SCOPE_MODERN)
+                || scopePackages.contains(SYSTEM_SCOPE_ANDROID_ALIAS));
+    }
+}

--- a/app/src/main/java/com/dpis/module/settings/SystemScopeCoordinator.java
+++ b/app/src/main/java/com/dpis/module/settings/SystemScopeCoordinator.java
@@ -12,8 +12,6 @@ import java.util.List;
 import io.github.libxposed.service.XposedService;
 
 public final class SystemScopeCoordinator {
-    private static final String SYSTEM_SCOPE_MODERN = "system";
-
     public interface Host {
         void showToast(int messageResId, Object... formatArgs);
 
@@ -120,7 +118,7 @@ public final class SystemScopeCoordinator {
         if (serviceAvailable) {
             try {
                 List<String> scope = service.getScope();
-                scopeSelected = scope != null && scope.contains(SYSTEM_SCOPE_MODERN);
+                scopeSelected = SystemFrameworkScope.containsSystemScope(scope);
             } catch (RuntimeException ignored) {
                 scopeSelected = false;
             }

--- a/app/src/test/java/com/dpis/module/InstalledAppCatalogCoordinatorTest.java
+++ b/app/src/test/java/com/dpis/module/InstalledAppCatalogCoordinatorTest.java
@@ -74,6 +74,49 @@ public class InstalledAppCatalogCoordinatorTest {
     }
 
     @Test
+    public void userVisibleConfiguredPackagesExcludesPersistedSystemFrameworkAliases() {
+        FakePrefs prefs = new FakePrefs();
+        DpisConfigStore store = new DpisConfigStore(prefs);
+        store.setTargetFontScalePercent("system", 125);
+        store.setTargetFontScalePercent("android", 125);
+        store.setTargetFontScalePercent("com.example.saved", 125);
+
+        Set<String> configured = InstalledAppCatalogCoordinator
+                .userVisibleConfiguredPackages(store);
+
+        assertTrue(configured.contains("com.example.saved"));
+        assertFalse(configured.contains("system"));
+        assertFalse(configured.contains("android"));
+    }
+
+    @Test
+    public void userVisibleConfiguredPackagesExcludesSystemFrameworkScopeAliases() {
+        Set<String> configured = InstalledAppCatalogCoordinator
+                .userVisibleConfiguredPackages(
+                        null,
+                        Set.of("system", "android", "com.example.injected"),
+                        true);
+
+        assertTrue(configured.contains("com.example.injected"));
+        assertFalse(configured.contains("system"));
+        assertFalse(configured.contains("android"));
+    }
+
+    @Test
+    public void systemFrameworkScopeAliasesAreNotConfiguredByScopeOnlyState() {
+        assertFalse(InstalledAppCatalogCoordinator.isUserVisibleConfiguredPackage(
+                null,
+                "system",
+                true,
+                true));
+        assertFalse(InstalledAppCatalogCoordinator.isUserVisibleConfiguredPackage(
+                null,
+                "android",
+                true,
+                true));
+    }
+
+    @Test
     public void unconfiguredItemUsesTheSameDefaultStatusWithoutStoreReads() {
         AppListItem item = InstalledAppCatalogCoordinator.createUnconfiguredAppListItem(
                 "Plain", "com.example.plain", false, true, false, false, true);

--- a/app/src/test/java/com/dpis/module/MainActivityConfiguredCountTest.java
+++ b/app/src/test/java/com/dpis/module/MainActivityConfiguredCountTest.java
@@ -30,6 +30,16 @@ public class MainActivityConfiguredCountTest {
     }
 
     @Test
+    public void configuredCountExcludesSystemFrameworkScopeAliases() {
+        assertEquals(1, MainActivity.countUserVisibleConfiguredPackages(
+                null,
+                new MainActivity.ScopeState(Set.of(
+                        "system",
+                        "android",
+                        "com.example.injected"), true)));
+    }
+
+    @Test
     public void configuredCountMatchesKnownScopeOnlyPackage() {
         assertEquals(1, MainActivity.countUserVisibleConfiguredPackages(
                 null,

--- a/app/src/test/java/com/dpis/module/SystemScopeCoordinatorBehaviorTest.java
+++ b/app/src/test/java/com/dpis/module/SystemScopeCoordinatorBehaviorTest.java
@@ -1,13 +1,30 @@
 package com.dpis.module;
 
+import com.dpis.module.settings.SystemFrameworkScope;
 import com.dpis.module.settings.SystemScopeCoordinator;
 
 import org.junit.Test;
+
+import java.util.Set;
 
 import static org.junit.Assert.assertFalse;
 import static org.junit.Assert.assertTrue;
 
 public class SystemScopeCoordinatorBehaviorTest {
+    @Test
+    public void systemScopeResolverAcceptsModernAndLegacyAliases() {
+        assertTrue(SystemFrameworkScope.containsSystemScope(Set.of("system")));
+        assertTrue(SystemFrameworkScope.containsSystemScope(Set.of("android")));
+        assertFalse(SystemFrameworkScope.containsSystemScope(Set.of("com.example.app")));
+    }
+
+    @Test
+    public void systemFrameworkScopeAliasesAreNotUserAppTargets() {
+        assertTrue(SystemFrameworkScope.isFrameworkScopePackage("system"));
+        assertTrue(SystemFrameworkScope.isFrameworkScopePackage("android"));
+        assertFalse(SystemFrameworkScope.isFrameworkScopePackage("com.example.app"));
+    }
+
     @Test
     public void legacyFallsBackToDesiredWhenServiceUnavailable() {
         assertTrue(SystemScopeCoordinator.resolveSystemHookEffectiveEnabled(


### PR DESCRIPTION
## Summary
- exclude system-framework scope aliases (`system` / `android`) from user-visible configured-app sets, rows, and home counts
- keep the same aliases valid for resolving system-server hook scope selection
- add regression coverage for persisted aliases, scope-only aliases, and modern/legacy system scope resolution

## Local validation
- `git fetch origin main --prune` confirmed `main` == `origin/main` before branching (`0 0`)
- `git diff --check` passes
- Targeted Gradle tests could not run locally because this Android PRoot environment cannot start/download the required JDK toolchain; CI is the intended validation source for this branch.