### PR TITLE
chore: drop stale TODOs for finished policies

### DIFF
--- a/app/src/main/java/com/dpis/module/appconfig/ConfigDraftSaveSemantics.java
+++ b/app/src/main/java/com/dpis/module/appconfig/ConfigDraftSaveSemantics.java
@@ -8,9 +8,6 @@ final class ConfigDraftSaveSemantics {
     private ConfigDraftSaveSemantics() {
     }
 
-    // TODO: If app config, landscape detail, quick template, and global prefill
-    // keep growing together, introduce a shared editor-draft request/result type
-    // here so handlers reuse one parser while keeping their own side effects.
     static String viewportTargetTypeForSave(String viewportTargetType) {
         return ViewportTargetType.normalize(viewportTargetType);
     }

--- a/app/src/main/java/com/dpis/module/runtime/systemserver/SystemServerDisplayEnvironmentInstaller.java
+++ b/app/src/main/java/com/dpis/module/runtime/systemserver/SystemServerDisplayEnvironmentInstaller.java
@@ -2115,8 +2115,8 @@ public final class SystemServerDisplayEnvironmentInstaller {
                                             PerAppDisplayEnvironment environment,
                                             PerAppDisplayConfig config) {
         boolean changed = false;
-        // TODO(system-mutation-scheduler): give each field an explicit baseline
-        // policy. VIEWPORT uses a marker-gated baseline model and can be applied
+        // Field baseline is owned by SystemServerMutationPolicy.shouldApplyMutationField.
+        // VIEWPORT uses a marker-gated baseline model and can be applied
         // across multiple lifecycle entries; FONT_SCALE is launch-only here
         // because changing Configuration.fontScale during later config dispatch
         // can produce CONFIG_FONT_SCALE relaunches.

--- a/app/src/test/java/com/dpis/module/runtime/systemserver/SystemServerDisplayEnvironmentInstallerMutationPolicyTest.java
+++ b/app/src/test/java/com/dpis/module/runtime/systemserver/SystemServerDisplayEnvironmentInstallerMutationPolicyTest.java
@@ -496,12 +496,12 @@ public class SystemServerDisplayEnvironmentInstallerMutationPolicyTest {
     }
 
     @Test
-    public void systemServerMutationSchedulerTodoDocumentsFieldSemantics()
+    public void applyEnvironmentDefersFieldBaselineToMutationPolicy()
             throws IOException {
         String installer = read("src/main/java/com/dpis/module/runtime/systemserver/SystemServerDisplayEnvironmentInstaller.java");
         String policy = read("src/main/java/com/dpis/module/runtime/systemserver/SystemServerMutationPolicy.java");
 
-        assertTrue(installer.contains("TODO(system-mutation-scheduler)"));
+        assertTrue(installer.contains("SystemServerMutationPolicy.shouldApplyMutationField"));
         assertTrue(installer.contains("SystemServerMutationField.VIEWPORT"));
         assertTrue(installer.contains("SystemServerMutationField.FONT_SCALE"));
         assertTrue(installer.contains("VIEWPORT uses a marker-gated"));


### PR DESCRIPTION
## Summary

Close two stale `TODO` comments that no longer describe remaining work.

- `ConfigDraftSaveSemantics` no longer carries a speculative shared-draft TODO. App config, landscape, template, and prefill still keep their own save handlers.
- `applyEnvironment` already defers field baseline to `SystemServerMutationPolicy.shouldApplyMutationField` (VIEWPORT across entries, FONT_SCALE launch-only). The comment now states that, and the source test pins the policy wiring instead of the word `TODO`.

This is comment and test-anchor cleanup only. Runtime mutation behavior is unchanged.

Remaining TODOs are left in place: WeChat `wekit_dpi` upgrade migration, and Java `AlertDialog` / View binder bridges that still have live callers.

## Verification

- `./gradlew :app:testAllDebugUnitTests`
- Android Studio CLI was `NOT READY`; `analyze-file` was not run
