### PR TITLE
refactor: own template sort dialog in Compose state

### DIFF
--- a/app/src/main/java/com/dpis/module/templates/QuickTemplateSortDialog.kt
+++ b/app/src/main/java/com/dpis/module/templates/QuickTemplateSortDialog.kt
@@ -1,7 +1,5 @@
 package com.dpis.module.templates
 
-import android.app.Activity
-import androidx.annotation.StringRes
 import androidx.compose.foundation.layout.Arrangement
 import androidx.compose.foundation.layout.PaddingValues
 import androidx.compose.foundation.layout.Row
@@ -24,77 +22,35 @@ import androidx.compose.ui.Alignment
 import androidx.compose.ui.Modifier
 import androidx.compose.ui.draw.clip
 import androidx.compose.ui.draw.shadow
-import androidx.compose.ui.platform.ComposeView
-import androidx.compose.ui.platform.ViewCompositionStrategy
 import androidx.compose.ui.res.painterResource
 import androidx.compose.ui.res.stringResource
 import androidx.compose.ui.text.style.TextOverflow
 import androidx.compose.ui.tooling.preview.Preview
 import androidx.compose.ui.unit.dp
 import com.dpis.module.R
-import com.dpis.module.ui.DialogWindowEdgeToEdge
-import com.dpis.module.ui.DialogWindowSizer
 import com.dpis.module.ui.compose.ComposeDesignSystem
 import com.dpis.module.ui.compose.FeedbackButton
 import com.dpis.module.ui.compose.ReorderableDragFeedback
 import com.dpis.module.ui.compose.rememberClickAction
-import com.dpis.module.ui.compose.resolveDarkTheme
 import com.dpis.module.ui.dialog.DialogColumn
 import com.dpis.module.ui.dialog.DialogTitle
-import com.google.android.material.dialog.MaterialAlertDialogBuilder
+import com.dpis.module.ui.dialog.ModalDialog
 import sh.calvin.reorderable.ReorderableItem
 import sh.calvin.reorderable.rememberReorderableLazyListState
 
-/** Legacy platform-dialog bridge for View and Wear callers; Compose pages use the content below. */
-object QuickTemplateSortDialog {
-    // TODO: Migrate after Java callers stop retaining the AlertDialog for imperative dismissal.
-    interface Host {
-        /** Persists the current order. Returning false leaves the dialog at the previous order. */
-        fun onOrderChanged(orderedIds: List<String>): Boolean
-        fun showToast(@StringRes messageResId: Int)
-    }
-
-    @JvmStatic
-    fun show(
-        activity: Activity?,
-        templates: List<QuickTemplateStore.QuickTemplate>?,
-        host: Host?
-    ) {
-        if (activity == null || templates.isNullOrEmpty()) return
-
-        val composeView = ComposeView(activity).apply {
-            setViewCompositionStrategy(ViewCompositionStrategy.DisposeOnDetachedFromWindow)
-        }
-        val dialog = MaterialAlertDialogBuilder(activity)
-            .setView(composeView)
-            .create()
-        composeView.setContent {
-            ComposeDesignSystem(darkTheme = resolveDarkTheme()) {
-                QuickTemplateSortContent(
-                    initialItems = templates.map {
-                        QuickTemplateSortItem(
-                            it.id,
-                            it.name.orEmpty()
-                        )
-                    },
-                    onOrderChanged = { orderedIds ->
-                        val currentHost = host
-                        if (currentHost == null) {
-                            true
-                        } else {
-                            currentHost.onOrderChanged(orderedIds).also { saved ->
-                                if (!saved) currentHost.showToast(R.string.quick_template_sort_failed)
-                            }
-                        }
-                    },
-                    onDone = dialog::dismiss
-                )
-            }
-        }
-        dialog.setCanceledOnTouchOutside(true)
-        dialog.show()
-        DialogWindowEdgeToEdge.apply(dialog)
-        DialogWindowSizer.applyLargeWidth(dialog, activity)
+/** Compose-owned sort dialog for phone, tablet, and Wear template workspaces. */
+@Composable
+internal fun QuickTemplateSortDialog(
+    items: List<QuickTemplateSortItem>,
+    onOrderChanged: (List<String>) -> Boolean,
+    onDismiss: () -> Unit,
+) {
+    ModalDialog(onDismissRequest = onDismiss) {
+        QuickTemplateSortContent(
+            initialItems = items,
+            onOrderChanged = onOrderChanged,
+            onDone = onDismiss,
+        )
     }
 }
 

--- a/app/src/main/java/com/dpis/module/templates/TemplateWorkspaceCoordinator.kt
+++ b/app/src/main/java/com/dpis/module/templates/TemplateWorkspaceCoordinator.kt
@@ -151,18 +151,6 @@ class TemplateWorkspaceCoordinator @JvmOverloads constructor(
 
         override fun createTemplate() = openQuickTemplate(null)
 
-        override fun sortTemplates() {
-            QuickTemplateSortDialog.show(
-                activity,
-                QuickTemplateStore(activity).readAll(),
-                object : QuickTemplateSortDialog.Host {
-                    override fun onOrderChanged(orderedIds: List<String>) = reorderTemplates(orderedIds)
-
-                    override fun showToast(messageResId: Int) = host.showToast(messageResId)
-                },
-            )
-        }
-
         override fun reorderTemplates(orderedIds: List<String>): Boolean {
             val reordered = QuickTemplateStore(activity).reorder(orderedIds)
             if (reordered) {
@@ -401,7 +389,11 @@ class TemplateWorkspaceCoordinator @JvmOverloads constructor(
                 override fun edit(templateId: String) = openQuickTemplate(templateId)
                 override fun select(templateId: String) = openQuickTemplateTargets(templateId)
                 override fun create() = openQuickTemplate(null)
-                override fun sort(templates: List<QuickTemplateStore.QuickTemplate>) = actions.sortTemplates()
+                override fun sort(templates: List<QuickTemplateStore.QuickTemplate>) {
+                    // Sort dialog visibility is owned by Compose phone/Wear. This View binder is
+                    // only used when the Compose shell is absent.
+                    if (templates.isEmpty()) return
+                }
             },
         )
     }

--- a/app/src/main/java/com/dpis/module/templates/TemplateWorkspacePresentation.kt
+++ b/app/src/main/java/com/dpis/module/templates/TemplateWorkspacePresentation.kt
@@ -51,9 +51,7 @@ object TemplateWorkspacePresentation {
     interface Actions {
         fun editGlobalPrefill()
         fun createTemplate()
-        /** Legacy View and Wear entry point while those surfaces retain platform dialog ownership. */
-        fun sortTemplates()
-        /** Persists the full template order; the Compose page owns dialog visibility. */
+        /** Persists the full template order; Compose owns dialog visibility. */
         fun reorderTemplates(orderedIds: List<String>): Boolean
         fun applyTemplate(id: String)
         fun editTemplate(id: String)

--- a/app/src/main/java/com/dpis/module/templates/presentation/TemplateWorkspaceContent.kt
+++ b/app/src/main/java/com/dpis/module/templates/presentation/TemplateWorkspaceContent.kt
@@ -51,7 +51,7 @@ import com.dpis.module.ConfigEditorDestination
 import com.dpis.module.R
 import com.dpis.module.fonts.FontApplyMode
 import com.dpis.module.fonts.hookdomain.FontHookDomainRegistry
-import com.dpis.module.templates.QuickTemplateSortContent
+import com.dpis.module.templates.QuickTemplateSortDialog
 import com.dpis.module.templates.QuickTemplateStore
 import com.dpis.module.templates.QuickTemplateTargetsPresentationController
 import com.dpis.module.templates.TemplateEditorForm
@@ -442,13 +442,11 @@ internal fun TemplateWorkspaceContent(
         }
     }
     if (sortDialogVisible) {
-        ModalDialog(onDismissRequest = { sortDialogVisible = false }) {
-            QuickTemplateSortContent(
-                initialItems = state.sortItems,
-                onOrderChanged = state.actions::reorderTemplates,
-                onDone = { sortDialogVisible = false },
-            )
-        }
+        QuickTemplateSortDialog(
+            items = state.sortItems,
+            onOrderChanged = state.actions::reorderTemplates,
+            onDismiss = { sortDialogVisible = false },
+        )
     }
     if (deleteConfirmationVisible) {
         ConfirmAlertDialog(

--- a/app/src/main/java/com/dpis/module/ui/presentation/wear/WearWorkspaceContent.kt
+++ b/app/src/main/java/com/dpis/module/ui/presentation/wear/WearWorkspaceContent.kt
@@ -31,6 +31,7 @@ import androidx.compose.runtime.LaunchedEffect
 import androidx.compose.runtime.getValue
 import androidx.compose.runtime.mutableStateOf
 import androidx.compose.runtime.remember
+import androidx.compose.runtime.saveable.rememberSaveable
 import androidx.compose.runtime.setValue
 import androidx.compose.ui.Alignment
 import androidx.compose.ui.Modifier
@@ -78,6 +79,7 @@ import com.dpis.module.fonts.hookdomain.FontHookDomainRegistry
 import com.dpis.module.home.HomeWorkspaceState
 import com.dpis.module.hooks.HookDomainOverrideStore
 import com.dpis.module.settings.SystemFontScaleToolState
+import com.dpis.module.templates.QuickTemplateSortDialog
 import com.dpis.module.templates.QuickTemplateStore
 import com.dpis.module.templates.TemplateEditorForm
 import com.dpis.module.templates.TemplateWorkspacePresentation
@@ -443,6 +445,7 @@ internal fun WearTemplateWorkspaceContent(
         return
     }
     val context = LocalContext.current
+    var sortDialogVisible by rememberSaveable { mutableStateOf(false) }
     WearWorkspaceList(title = R.string.workspace_template) {
         wearButton(
             key = "global",
@@ -457,7 +460,13 @@ internal fun WearTemplateWorkspaceContent(
             icon = R.drawable.ic_add_24,
             onClick = state.actions::createTemplate
         )
-        wearButton("sort", context.getString(R.string.quick_template_sort_title), icon = R.drawable.ic_sort_24, onClick = state.actions::sortTemplates)
+        wearButton(
+            "sort",
+            context.getString(R.string.quick_template_sort_title),
+            icon = R.drawable.ic_sort_24,
+            enabled = state.sortItems.isNotEmpty(),
+            onClick = { sortDialogVisible = true },
+        )
         state.templates.forEach { template ->
             wearButton(
                 key = template.id,
@@ -469,6 +478,13 @@ internal fun WearTemplateWorkspaceContent(
             wearButton("apply:${template.id}", context.getString(R.string.template_workspace_action_apply), template.name, R.drawable.ic_check_24, onClick = { state.actions.applyTemplate(template.id) })
             wearButton("targets:${template.id}", context.getString(R.string.template_workspace_action_select_apps), template.name, R.drawable.ic_apps_24, onClick = { state.actions.selectTargets(template.id) })
         }
+    }
+    if (sortDialogVisible && state.sortItems.isNotEmpty()) {
+        QuickTemplateSortDialog(
+            items = state.sortItems,
+            onOrderChanged = state.actions::reorderTemplates,
+            onDismiss = { sortDialogVisible = false },
+        )
     }
 }
 

--- a/app/src/test/java/com/dpis/module/templates/TemplateWorkspaceLayoutSmokeTest.kt
+++ b/app/src/test/java/com/dpis/module/templates/TemplateWorkspaceLayoutSmokeTest.kt
@@ -48,7 +48,7 @@ class TemplateWorkspaceLayoutSmokeTest {
         card.assertNotContainsAll("android:id=\"@+id/quick_template_updated\"", "android:id=\"@+id/quick_template_missing_font\"")
         assertDashedEmptySummaryState(elementWithId(card, "quick_template_empty_summary"))
         read("src/main/java/com/dpis/module/templates/QuickTemplateSortDialog.kt").assertContainsAll("QuickTemplateSortContent(", "ReorderableItem", "longPressDraggableHandle", "R.drawable.ic_drag_indicator_24")
-        read("src/main/java/com/dpis/module/templates/presentation/TemplateWorkspaceContent.kt").assertContainsAll("var sortDialogVisible by rememberSaveable", "ModalDialog(onDismissRequest", "initialItems = state.sortItems", "onOrderChanged = state.actions::reorderTemplates")
+        read("src/main/java/com/dpis/module/templates/presentation/TemplateWorkspaceContent.kt").assertContainsAll("var sortDialogVisible by rememberSaveable", "QuickTemplateSortDialog(", "items = state.sortItems", "onOrderChanged = state.actions::reorderTemplates")
         read("src/main/java/com/dpis/module/templates/TemplateWorkspacePresentation.kt").assertContainsAll("val sortItems: List<QuickTemplateSortItem>", "fun reorderTemplates(orderedIds: List<String>): Boolean")
         read("src/main/java/com/dpis/module/templates/TemplateWorkspaceCoordinator.kt").assertContainsAll(
             "class TemplateWorkspaceCoordinator", "private val presentation = TemplateWorkspacePresentationController",
@@ -74,7 +74,8 @@ class TemplateWorkspaceLayoutSmokeTest {
         adapter.assertContainsAll("R.id.quick_template_summary_chips", "TemplateSummaryChipBinder", "R.id.quick_template_apply_button", "R.id.quick_template_edit_button", "R.id.quick_template_select_button")
         adapter.assertNotContainsAll("quick_template_updated")
         read("src/main/java/com/dpis/module/templates/TemplateWorkspaceBinder.kt").assertContainsAll("quick_template_sort_button")
-        read("src/main/java/com/dpis/module/templates/QuickTemplateSortDialog.kt").assertContainsAll("DialogWindowSizer.applyLargeWidth(dialog, activity)")
+        read("src/main/java/com/dpis/module/templates/QuickTemplateSortDialog.kt").assertContainsAll("ModalDialog(onDismissRequest = onDismiss)", "fun QuickTemplateSortDialog(")
+        read("src/main/java/com/dpis/module/ui/presentation/wear/WearWorkspaceContent.kt").assertContainsAll("var sortDialogVisible by rememberSaveable", "QuickTemplateSortDialog(", "enabled = state.sortItems.isNotEmpty()")
         read("src/main/java/com/dpis/module/MainActivity.java").apply {
             assertContainsAll("private TemplateWorkspaceActivitySession workspaceSession;", "ensureWorkspaceSession()")
             assertContainsAll("TemplateWorkspaceActivitySession.State", "attachLegacyViews(")


### PR DESCRIPTION
## Summary

Close the template-sort `TODO` by owning dialog visibility in Compose state.

- Phone/tablet already used `ModalDialog`; they now share `QuickTemplateSortDialog`.
- Wear uses the same Compose dialog instead of `QuickTemplateSortDialog.show()`.
- The `AlertDialog` / `MaterialAlertDialogBuilder` bridge is gone. Order persistence stays on `reorderTemplates`.

The leftover View template binder no longer opens a platform dialog. That layout is only bound when the Compose shell is absent.

## Verification

- `./gradlew :app:testAllDebugUnitTests`
